### PR TITLE
Ciphertext +/- Plaintext

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ class FHE {
     encodeVecInt(List~int~): Plaintext
     decodeVecInt(Plaintext, int): List~int~
     add(Ciphertext, Ciphertext): Ciphertext
+    addPlain(Ciphertext, Plaintext): Ciphertext
     subtract(Ciphertext, Ciphertext): Ciphertext
+    subtractPlain(Ciphertext, Plaintext): Ciphertext
 }
 
 ```
@@ -167,7 +169,7 @@ class Afhe {
     invariant_noise_budget(Ciphertext): int
     encode_int(vector~uint64_t~, Plaintext): void
     decode_int(Plaintext, vector~uint64~): void
-    add(Ciphertext, Ciphertext, Ciphertext):
+    add(Ciphertext, Ciphertext, Ciphertext): void
     subtract(Ciphertext, Ciphertext, Ciphertext): void
 }
 
@@ -191,7 +193,9 @@ class FHE {
     encode_int(backend_t, Afhe, uint64_t, int): Plaintext
     decode_int(backend_t, Afhe, Plaintext): unint64
     add(backend_t, Afhe, Ciphertext, Ciphertext): Ciphertext
+    add_plain(backend_t, Afhe, Ciphertext, Plaintext): Ciphertext
     subtract(backend_t, Afhe, Ciphertext, Ciphertext): Ciphertext
+    add_subtract(backend_t, Afhe, Ciphertext, Plaintext): Ciphertext
 }
 
 Afhe --> FHE

--- a/dart/lib/afhe/operation.dart
+++ b/dart/lib/afhe/operation.dart
@@ -13,6 +13,14 @@ typedef Add = Pointer Function(
 
 final Add c_add = dylib.lookup<NativeFunction<AddC>>('add').asFunction();
 
+typedef AddPlainC = Pointer Function(
+    Int backend, Pointer library, Pointer ciphertext, Pointer plaintext);
+
+typedef AddPlain = Pointer Function(
+    int backend, Pointer library, Pointer ciphertext, Pointer plaintext);
+
+final AddPlain c_add_plain = dylib.lookup<NativeFunction<AddPlainC>>('add_plain').asFunction();
+
 // --- subtract ---
 
 typedef SubC = Pointer Function(

--- a/dart/lib/afhe/operation.dart
+++ b/dart/lib/afhe/operation.dart
@@ -30,3 +30,11 @@ typedef Sub = Pointer Function(
     int backend, Pointer library, Pointer ciphertext1, Pointer ciphertext2);
 
 final Sub c_subtract = dylib.lookup<NativeFunction<SubC>>('subtract').asFunction();
+
+typedef SubPlainC = Pointer Function(
+    Int backend, Pointer library, Pointer ciphertext, Pointer plaintext);
+
+typedef SubPlain = Pointer Function(
+    int backend, Pointer library, Pointer ciphertext, Pointer plaintext);
+
+final SubPlain c_subtract_plain = dylib.lookup<NativeFunction<SubPlainC>>('subtract_plain').asFunction();

--- a/dart/lib/fhe.dart
+++ b/dart/lib/fhe.dart
@@ -150,4 +150,12 @@ class FHE {
     ctx.library = ptr;
     return ctx;
   }
+
+  Ciphertext subtractPlain(Ciphertext a, Plaintext b) {
+    Pointer ptr = c_subtract_plain(backend.value, library, a.library, b.obj);
+
+    Ciphertext ctx = Ciphertext(backend);
+    ctx.library = ptr;
+    return ctx;
+  }
 }

--- a/dart/lib/fhe.dart
+++ b/dart/lib/fhe.dart
@@ -135,6 +135,14 @@ class FHE {
     return ctx;
   }
 
+  Ciphertext addPlain(Ciphertext a, Plaintext b) {
+    Pointer ptr = c_add_plain(backend.value, library, a.library, b.obj);
+
+    Ciphertext ctx = Ciphertext(backend);
+    ctx.library = ptr;
+    return ctx;
+  }
+
   Ciphertext subtract(Ciphertext a, Ciphertext b) {
     Pointer ptr = c_subtract(backend.value, library, a.library, b.library);
 

--- a/dart/test/seal/addition_test.dart
+++ b/dart/test/seal/addition_test.dart
@@ -47,10 +47,12 @@ void main() {
     };
 
     for (var sch in schemes) {
-      expect(280.toRadixString(16),
-          sealAddition(sch, 200.toRadixString(16), 80.toRadixString(16), ctx));
-      expect(280.toRadixString(16),
-          sealAddition(sch, 200.toRadixString(16), 80.toRadixString(16), ctx, encryptAddend: false));
+      expect(
+        280.toRadixString(16),
+        sealAddition(sch, 200.toRadixString(16), 80.toRadixString(16), ctx));
+      expect(
+        280.toRadixString(16),
+        sealAddition(sch, 200.toRadixString(16), 80.toRadixString(16), ctx, encryptAddend: false));
     }
 
     // Otherwise, you are forced to increase plaintext modulus,
@@ -65,11 +67,11 @@ void main() {
     ctx['ptMod'] = 4196;
     for (var sch in schemes) {
       expect(
-          2800.toRadixString(16).toLowerCase(),
-          sealAddition(sch, 2000.toRadixString(16), 800.toRadixString(16), ctx));
+        2800.toRadixString(16).toLowerCase(),
+        sealAddition(sch, 2000.toRadixString(16), 800.toRadixString(16), ctx));
       expect(
-          2800.toRadixString(16).toLowerCase(),
-          sealAddition(sch, 2000.toRadixString(16), 800.toRadixString(16), ctx, encryptAddend: false));
+        2800.toRadixString(16).toLowerCase(),
+        sealAddition(sch, 2000.toRadixString(16), 800.toRadixString(16), ctx, encryptAddend: false));
     }
   });
 

--- a/dart/test/seal/addition_test.dart
+++ b/dart/test/seal/addition_test.dart
@@ -5,7 +5,7 @@ import 'package:fhel/afhe/plaintext.dart';
 // Least Significant Bit (LSB), Most Significant Bit (MSB)
 const schemes = ['bgv', 'bfv'];
 
-String sealAddition(String scheme, String a, String b, Map<String, int> ctx) {
+String sealAddition(String scheme, String a, String b, Map<String, int> ctx, {bool encryptAddend=true}) {
   final fhe = FHE.withScheme('seal', scheme);
   String status = fhe.genContext(ctx);
   expect(status, 'success: valid');
@@ -13,25 +13,33 @@ String sealAddition(String scheme, String a, String b, Map<String, int> ctx) {
   final pt_x = Plaintext.withValue(fhe.backend, a);
   final ct_x = fhe.encrypt(pt_x);
   final pt_add = Plaintext.withValue(fhe.backend, b);
-  final ct_add = fhe.encrypt(pt_add);
-  final ct_res = fhe.add(ct_x, ct_add);
+
+  // Optionally, addend can be plaintext
+  var ct_res;
+  if (encryptAddend) {
+    final ct_add = fhe.encrypt(pt_add);
+    ct_res = fhe.add(ct_x, ct_add);
+  } else {
+    ct_res = fhe.addPlain(ct_x, pt_add);
+  }
   final pt_res = fhe.decrypt(ct_res);
   return pt_res.text.toLowerCase();
 }
 
 void main() {
-  test("SEAL Integer Addition", () {
+  test("Integer Addition", () {
     Map<String, int> ctx = {
       'polyModDegree': 4096,
       'ptMod': 1024,
       'secLevel': 128
     };
     for (var sch in schemes) {
-      expect(sealAddition(sch, '200', '80', ctx), '280');
+      expect('280', sealAddition(sch, '200', '80', ctx));
+      expect('280', sealAddition(sch, '200', '80', ctx, encryptAddend: false));
     }
   });
 
-  test("SEAL Hexadecimal Addition", () {
+  test("Hexadecimal Addition", () {
     Map<String, int> ctx = {
       'polyModDegree': 4096,
       'ptMod': 1024,
@@ -41,13 +49,16 @@ void main() {
     for (var sch in schemes) {
       expect(280.toRadixString(16),
           sealAddition(sch, 200.toRadixString(16), 80.toRadixString(16), ctx));
+      expect(280.toRadixString(16),
+          sealAddition(sch, 200.toRadixString(16), 80.toRadixString(16), ctx, encryptAddend: false));
     }
 
     // Otherwise, you are forced to increase plaintext modulus,
     // resulting in more noise growth and failed decryption
     ctx['ptMod'] = 67136;
     for (var sch in schemes) {
-      expect(sealAddition(sch, '2000', '2000', ctx), '4000');
+      expect('4000', sealAddition(sch, '2000', '2000', ctx));
+      expect('4000', sealAddition(sch, '2000', '2000', ctx, encryptAddend: false));
     }
 
     // When using hexadecimal, plain modulus can be lower
@@ -55,12 +66,14 @@ void main() {
     for (var sch in schemes) {
       expect(
           2800.toRadixString(16).toLowerCase(),
-          sealAddition(
-              sch, 2000.toRadixString(16), 800.toRadixString(16), ctx));
+          sealAddition(sch, 2000.toRadixString(16), 800.toRadixString(16), ctx));
+      expect(
+          2800.toRadixString(16).toLowerCase(),
+          sealAddition(sch, 2000.toRadixString(16), 800.toRadixString(16), ctx, encryptAddend: false));
     }
   });
 
-  test("SEAL List<int> Addition", () {
+  test("List<int> Addition", () {
     for (var sch in schemes) {
       final fhe = FHE.withScheme('seal', sch);
       Map<String, int> ctx = {
@@ -77,15 +90,26 @@ void main() {
 
       List<int> add = x;
       final pt_add = fhe.encodeVecInt(add);
-      final ct_add = fhe.encrypt(pt_add);
 
-      final ct_res = fhe.add(ct_x, ct_add);
+      // Optionally, addend can be plaintext
+      final ct_res = fhe.addPlain(ct_x, pt_add);
       final pt_res = fhe.decrypt(ct_res);
+      final actual = fhe.decodeVecInt(pt_res, 4);
 
       final expected = [2, 4, 6, 8];
-      final actual = fhe.decodeVecInt(pt_res, 4);
       for (int i = 0; i < actual.length; i++) {
         expect(actual[i], expected[i]);
+      }
+
+      // Traditionally, add two ciphertexts
+      final ct_add_cipher = fhe.encrypt(pt_add);
+
+      final ct_res_cipher = fhe.add(ct_x, ct_add_cipher);
+      final pt_res_cipher = fhe.decrypt(ct_res_cipher);
+      final actual_cipher = fhe.decodeVecInt(pt_res_cipher, 4);
+
+      for (int i = 0; i < actual.length; i++) {
+        expect(actual_cipher[i], expected[i]);
       }
     }
   });

--- a/dart/test/seal/subtraction_test.dart
+++ b/dart/test/seal/subtraction_test.dart
@@ -5,7 +5,7 @@ import 'package:fhel/afhe/plaintext.dart';
 // Least Significant Bit (LSB), Most Significant Bit (MSB)
 const schemes = ['bgv', 'bfv'];
 
-String sealSubtraction(String scheme, String a, String b, Map<String, int> ctx) {
+String sealSubtraction(String scheme, String a, String b, Map<String, int> ctx, {bool encryptSubtrahend = true}) {
   final fhe = FHE.withScheme('seal', scheme);
   String status = fhe.genContext(ctx);
   expect(status, 'success: valid');
@@ -13,8 +13,14 @@ String sealSubtraction(String scheme, String a, String b, Map<String, int> ctx) 
   final pt_x = Plaintext.withValue(fhe.backend, a);
   final ct_x = fhe.encrypt(pt_x);
   final pt_sub = Plaintext.withValue(fhe.backend, b);
-  final ct_sub = fhe.encrypt(pt_sub);
-  final ct_res = fhe.subtract(ct_x, ct_sub);
+
+  var ct_res;
+  if (encryptSubtrahend) {
+    final ct_sub = fhe.encrypt(pt_sub);
+    ct_res = fhe.subtract(ct_x, ct_sub);
+  } else {
+    ct_res = fhe.subtractPlain(ct_x, pt_sub);
+  }
   final pt_res = fhe.decrypt(ct_res);
   return pt_res.text.toLowerCase();
 }
@@ -27,7 +33,8 @@ void main() {
       'secLevel': 128
     };
     for (var sch in schemes) {
-      expect(sealSubtraction(sch, '100', '100', ctx), '0');
+      expect('0', sealSubtraction(sch, '100', '100', ctx));
+      expect('0', sealSubtraction(sch, '100', '100', ctx, encryptSubtrahend: false));
     }
   });
 
@@ -39,24 +46,31 @@ void main() {
     };
 
     for (var sch in schemes) {
-      expect(120.toRadixString(16),
-          sealSubtraction(sch, 200.toRadixString(16), 80.toRadixString(16), ctx));
+      expect(
+        120.toRadixString(16),
+        sealSubtraction(sch, 200.toRadixString(16), 80.toRadixString(16), ctx));
+      expect(
+        120.toRadixString(16),
+        sealSubtraction(sch, 200.toRadixString(16), 80.toRadixString(16), ctx, encryptSubtrahend: false));
     }
 
     // Otherwise, you are forced to increase plaintext modulus,
     // resulting in more noise growth and failed decryption
     ctx['ptMod'] = 67136;
     for (var sch in schemes) {
-      expect(sealSubtraction(sch, '2000', '2000', ctx), '0');
+      expect('0', sealSubtraction(sch, '2000', '2000', ctx));
+      expect('0', sealSubtraction(sch, '2000', '2000', ctx, encryptSubtrahend: false));
     }
 
     // When using hexadecimal, plain modulus can be lower
     ctx['ptMod'] = 4196;
     for (var sch in schemes) {
       expect(
-          1200.toRadixString(16).toLowerCase(),
-          sealSubtraction(
-              sch, 2000.toRadixString(16), 800.toRadixString(16), ctx));
+        1200.toRadixString(16).toLowerCase(),
+        sealSubtraction(sch, 2000.toRadixString(16), 800.toRadixString(16), ctx));
+      expect(
+        1200.toRadixString(16).toLowerCase(),
+        sealSubtraction(sch, 2000.toRadixString(16), 800.toRadixString(16), ctx, encryptSubtrahend: false));
     }
   });
 
@@ -80,12 +94,16 @@ void main() {
       final ct_add = fhe.encrypt(pt_add);
 
       final ct_res = fhe.subtract(ct_x, ct_add);
+      final ct_res_cipher = fhe.subtractPlain(ct_x, pt_add);
       final pt_res = fhe.decrypt(ct_res);
+      final pt_res_cipher = fhe.decrypt(ct_res_cipher);
 
       final expected = [0, 0, 0, 0];
       final actual = fhe.decodeVecInt(pt_res, 4);
+      final actual_cipher = fhe.decodeVecInt(pt_res_cipher, 4);
       for (int i = 0; i < actual.length; i++) {
         expect(actual[i], expected[i]);
+        expect(actual_cipher[i], expected[i]);
       }
     }
   });

--- a/include/afhe.h
+++ b/include/afhe.h
@@ -181,6 +181,18 @@ public:
   // ------------------ Arithmetic ------------------
 
   /**
+   * @brief Adds plaintext to ciphertexts and stores the result in another ciphertext.
+   *
+   * This function performs the addition operation on plaintext and ciphertext and stores the result in a ciphertext.
+   * Can be used as an alternative to relinearization.
+   *
+   * @param ptx The plaintext to be added.
+   * @param ctxt The ciphertext to be added.
+   * @param ctxt_res The ciphertext where the result will be stored.
+   */
+  virtual void add(ACiphertext &ctxt, APlaintext &ptxt, ACiphertext &ctxt_res) = 0;
+
+  /**
    * @brief Adds two ciphertexts and stores the result in another ciphertext.
    *
    * This function performs the addition operation on two ciphertexts and stores the result in a third ciphertext.

--- a/include/afhe.h
+++ b/include/afhe.h
@@ -204,6 +204,18 @@ public:
   virtual void add(ACiphertext &ctxt1, ACiphertext &ctxt2, ACiphertext &ctxt_res) = 0;
 
   /**
+   * @brief Subtracts a plaintext from a ciphertext and stores the result in another ciphertext.
+   *
+   * This function performs the subtraction operation on a ciphertext and a plaintext and stores the result in a ciphertext.
+   * Can be used as an alternative to relinearization.
+   *
+   * @param ctxt The ciphertext to be subtracted from.
+   * @param ptxt The plaintext to be subtracted.
+   * @param ctxt_res The ciphertext where the result will be stored.
+   */
+  virtual void subtract(ACiphertext &ctxt, APlaintext &ptxt, ACiphertext &ctxt_res) = 0;
+
+  /**
    * @brief Subtracts two ciphertexts and stores the result in another ciphertext.
    *
    * This function performs the subtraction operation on two ciphertexts and stores the result in a third ciphertext.

--- a/include/backend/aseal.h
+++ b/include/backend/aseal.h
@@ -202,6 +202,7 @@ public:
 
   // ------------------ Arithmetic ------------------
 
+  void add(ACiphertext &ctxt, APlaintext &ptxt, ACiphertext &ctxt_res) override;
   void add(ACiphertext &ctxt1, ACiphertext &ctxt2, ACiphertext &ctxt_res) override;
   void subtract(ACiphertext &ctxt1, ACiphertext &ctxt2, ACiphertext &ctxt_res) override;
 };

--- a/include/backend/aseal.h
+++ b/include/backend/aseal.h
@@ -204,6 +204,7 @@ public:
 
   void add(ACiphertext &ctxt, APlaintext &ptxt, ACiphertext &ctxt_res) override;
   void add(ACiphertext &ctxt1, ACiphertext &ctxt2, ACiphertext &ctxt_res) override;
+  void subtract(ACiphertext &ctxt, APlaintext &ptxt, ACiphertext &ctxt_res) override;
   void subtract(ACiphertext &ctxt1, ACiphertext &ctxt2, ACiphertext &ctxt_res) override;
 };
 

--- a/include/backend/openfhe.h
+++ b/include/backend/openfhe.h
@@ -58,6 +58,9 @@ public:
     int invariant_noise_budget(ACiphertext &ctxt) override {
         return -1;
     }
+    void add(ACiphertext &ctxt, APlaintext &ptxt, ACiphertext &ctxt_res) override {
+        return;
+    }
     void add(ACiphertext &ctxt1, ACiphertext &ctxt2, ACiphertext &ctxt_out) override {
         return;
     }

--- a/include/backend/openfhe.h
+++ b/include/backend/openfhe.h
@@ -67,4 +67,7 @@ public:
     void subtract(ACiphertext &ctxt1, ACiphertext &ctxt2, ACiphertext &ctxt_out) override {
         return;
     }
+    void subtract(ACiphertext &ctxt, APlaintext &ptxt, ACiphertext &ctxt_out) override {
+        return;
+    }
 };

--- a/include/fhe.h
+++ b/include/fhe.h
@@ -192,6 +192,13 @@ extern "C" {
     ACiphertext* add(backend_t backend, Afhe* afhe, ACiphertext* ciphertext1, ACiphertext* ciphertext2);
 
     /**
+     * @brief Add a plaintext to a ciphertext.
+     * @param backend Backend library to use.
+     * @param afhe Pointer to the backend library.
+    */
+    ACiphertext* add_plain(backend_t backend, Afhe* afhe, ACiphertext* ciphertext, APlaintext* plaintext);
+
+    /**
      * @brief Subtract two ciphertexts.
      * @param backend Backend library to use.
      * @param afhe Pointer to the backend library.

--- a/include/fhe.h
+++ b/include/fhe.h
@@ -205,6 +205,14 @@ extern "C" {
     */
     ACiphertext* subtract(backend_t backend, Afhe* afhe, ACiphertext* ciphertext1, ACiphertext* ciphertext2);
 
+
+    /**
+     * @brief Subtract a plaintext from a ciphertext.
+     * @param backend Backend library to use.
+     * @param afhe Pointer to the backend library.
+    */
+    ACiphertext* subtract_plain(backend_t backend, Afhe* afhe, ACiphertext* ciphertext, APlaintext* plaintext);
+
     // const char* get_secret_key(Afhe* afhe);
 
     // const char* get_public_key(Afhe* afhe);

--- a/src/backend/aseal.cpp
+++ b/src/backend/aseal.cpp
@@ -176,6 +176,18 @@ void Aseal::decode_int(APlaintext &ptxt, vector<uint64_t> &data)
   this->encoder->decode(_to_plaintext(ptxt), data);
 }
 
+void Aseal::add(ACiphertext &ctxt, APlaintext &ptxt, ACiphertext &ctxt_res)
+{
+  // Gather current context, resolves object
+  auto &seal_context = *(this->get_context());
+
+  // Initialize Evaluator object
+  this->evaluator = make_shared<Evaluator>(seal_context);
+
+  // Add using casted types
+  this->evaluator->add_plain(_to_ciphertext(ctxt), _to_plaintext(ptxt), _to_ciphertext(ctxt_res));
+}
+
 void Aseal::add(ACiphertext &ctxt1, ACiphertext &ctxt2, ACiphertext &ctxt_res)
 {
   // Gather current context, resolves object

--- a/src/backend/aseal.cpp
+++ b/src/backend/aseal.cpp
@@ -200,6 +200,18 @@ void Aseal::add(ACiphertext &ctxt1, ACiphertext &ctxt2, ACiphertext &ctxt_res)
   this->evaluator->add(_to_ciphertext(ctxt1), _to_ciphertext(ctxt2), _to_ciphertext(ctxt_res));
 }
 
+void Aseal::subtract(ACiphertext &ctxt, APlaintext &ptxt, ACiphertext &ctxt_res)
+{
+  // Gather current context, resolves object
+  auto &seal_context = *(this->get_context());
+
+  // Initialize Evaluator object
+  this->evaluator = make_shared<Evaluator>(seal_context);
+
+  // Subtract using casted types
+  this->evaluator->sub_plain(_to_ciphertext(ctxt), _to_plaintext(ptxt), _to_ciphertext(ctxt_res));
+}
+
 void Aseal::subtract(ACiphertext &ctxt1, ACiphertext &ctxt2, ACiphertext &ctxt_res)
 {
   // Gather current context, resolves object

--- a/src/fhe.cpp
+++ b/src/fhe.cpp
@@ -200,6 +200,25 @@ ACiphertext* add_plain(backend_t backend, Afhe* afhe, ACiphertext* ctxt, APlaint
     }
 }
 
+ACiphertext* subtract_plain(backend_t backend, Afhe* afhe, ACiphertext* ctxt, APlaintext* ptxt) {
+    switch(backend)
+    {
+    case backend_t::seal_t:
+    {
+        ACiphertext* ctxt_res = init_ciphertext(backend);
+        try {
+            afhe->subtract(*ctxt, *ptxt, *ctxt_res);
+        }
+        catch (invalid_argument &e) {
+            cout << "error: [subtract_plain] " << e.what() << endl;
+        }
+        return ctxt_res;
+    }
+    default:
+        return init_ciphertext(backend);
+    }
+}
+
 ACiphertext* subtract(backend_t backend, Afhe* afhe, ACiphertext* ctxt1, ACiphertext* ctxt2) {
     switch(backend)
     {

--- a/src/fhe.cpp
+++ b/src/fhe.cpp
@@ -181,6 +181,25 @@ ACiphertext* add(backend_t backend, Afhe* afhe, ACiphertext* ctxt1, ACiphertext*
     }
 }
 
+ACiphertext* add_plain(backend_t backend, Afhe* afhe, ACiphertext* ctxt, APlaintext* ptxt) {
+    switch(backend)
+    {
+    case backend_t::seal_t:
+    {
+        ACiphertext* ctxt_res = init_ciphertext(backend);
+        try {
+            afhe->add(*ctxt, *ptxt, *ctxt_res);
+        }
+        catch (invalid_argument &e) {
+            cout << "error: [add_plain] " << e.what() << endl;
+        }
+        return ctxt_res;
+    }
+    default:
+        return init_ciphertext(backend);
+    }
+}
+
 ACiphertext* subtract(backend_t backend, Afhe* afhe, ACiphertext* ctxt1, ACiphertext* ctxt2) {
     switch(backend)
     {

--- a/test/seal/addition.cpp
+++ b/test/seal/addition.cpp
@@ -132,3 +132,53 @@ TEST(Add, VectorInteger) {
     }
   }
 }
+
+TEST(Add, PlaintextWithCiphertext) {
+  std::map<int, int> plaintextToModulus = {
+    {100, 1024},
+    {200, 1024},
+    {300, 1024},
+    {400, 1024},
+    {500, 1024},
+    {1000, 2048},
+    {2000, 4196},
+    {4000, 8392},
+    {5000, 16784}
+  };
+
+  for (const auto& scheme : {scheme::bgv, scheme::bfv}) {
+
+    for (const auto& pair : plaintextToModulus) {
+      int plaintext = pair.first;
+      int modulus = pair.second;
+
+      Aseal* fhe = new Aseal();
+
+      string ctx = fhe->ContextGen(scheme, 1024, 0, modulus, 128);
+
+      // Expect two strings not to be equal.
+      EXPECT_STREQ(ctx.c_str(), "success: valid");
+
+      fhe->KeyGen();
+      // Add plaintext (x) with ciphertext (y)
+      AsealPlaintext pt_x = AsealPlaintext(uint64_to_hex(plaintext));
+      AsealPlaintext pt_y = AsealPlaintext(uint64_to_hex(plaintext));
+      AsealCiphertext ct_x = AsealCiphertext();
+      AsealCiphertext ct_res = AsealCiphertext();
+
+      // Only one is required to be encrypted.
+      fhe->encrypt(pt_x, ct_x);
+      fhe->add(ct_x, pt_y, ct_res);
+
+      AsealPlaintext pt_res = AsealPlaintext();
+      fhe->decrypt(ct_res, pt_res);
+
+      int expect = plaintext + plaintext;
+
+      // Convert hexademical string to uint_64.
+      string res_hex = pt_res.to_string();
+      int res_int = hex_to_uint64(res_hex);
+      EXPECT_EQ(res_int, expect);
+    }
+  }
+}

--- a/test/seal/subtraction.cpp
+++ b/test/seal/subtraction.cpp
@@ -39,10 +39,14 @@ TEST(Subtract, IntegersToHexadecimal) {
 
       AsealPlaintext pt_res = AsealPlaintext();
       AsealCiphertext ct_res = AsealCiphertext();
+      AsealPlaintext pt_res_cipher = AsealPlaintext();
+      AsealCiphertext ct_res_cipher = AsealCiphertext();
 
       fhe->subtract(ct_x, ct_y, ct_res);
+      fhe->subtract(ct_x, pt_y, ct_res_cipher);
 
       fhe->decrypt(ct_res, pt_res);
+      fhe->decrypt(ct_res_cipher, pt_res_cipher);
 
       int expect = plaintext - plaintext;
 
@@ -50,6 +54,10 @@ TEST(Subtract, IntegersToHexadecimal) {
       string res_hex = pt_res.to_string();
       int res_int = hex_to_uint64(res_hex);
       EXPECT_EQ(res_int, expect);
+
+      string res_hex_cipher = pt_res_cipher.to_string();
+      int res_int_cipher = hex_to_uint64(res_hex_cipher);
+      EXPECT_EQ(res_int_cipher, expect);
     }
   }
 }
@@ -116,18 +124,27 @@ TEST(Subtract, VectorInteger) {
 
       AsealPlaintext pt_res = AsealPlaintext();
       AsealCiphertext ct_res = AsealCiphertext();
+      AsealPlaintext pt_res_cipher = AsealPlaintext();
+      AsealCiphertext ct_res_cipher = AsealCiphertext();
+
       fhe->subtract(ct_x, ct_sub, ct_res);
+      fhe->subtract(ct_x, pt_sub, ct_res_cipher);
 
       AsealPlaintext decrypt_res = AsealPlaintext();
+      AsealPlaintext decrypt_res_cipher = AsealPlaintext();
       fhe->decrypt(ct_res, decrypt_res);
+      fhe->decrypt(ct_res_cipher, decrypt_res_cipher);
 
       vector<uint64_t> decode_res;
+      vector<uint64_t> decode_res_cipher;
       fhe->decode_int(decrypt_res, decode_res);
+      fhe->decode_int(decrypt_res_cipher, decode_res_cipher);
 
       // Plaintext x and decoded_x must be equal.
       vector<uint16_t> expect = {1, 2, 3, 4, 0, 0, 0, 0};
       for (int i = 0; i < x.size(); i++) {
         EXPECT_EQ(expect[i], decode_res[i]);
+        EXPECT_EQ(expect[i], decode_res_cipher[i]);
       }
     }
   }


### PR DESCRIPTION
As a user, I would like to perform operations with Ciphertext and Plaintext.

* Dart does NOT allow for parameter overload: addPlain
* C supports parameter overload, but should follow dart pattern for consistency