### PR TITLE
Remove `backend_t` from FFI parameter

### DIFF
--- a/dart/lib/afhe.dart
+++ b/dart/lib/afhe.dart
@@ -41,15 +41,14 @@ class Afhe {
   ///
   /// The [library] stores the memory address of the underlying C++ object.
   Afhe(String backendName, String schemeName) {
-    scheme = Scheme.set(schemeName);
     backend = Backend.set(backendName);
+    scheme = Scheme.set(schemeName);
     library = _c_init_backend(backend.value);
   }
 
   /// Generates a context for the Brakerski-Fan-Vercauteren (BFV) scheme.
   String _contextBFV(Map context) {
     final ptr = _c_gen_context(
-        backend.value,
         library,
         scheme.value,
         context['polyModDegree'],
@@ -85,7 +84,7 @@ class Afhe {
 
   /// Generates the public and secret keys for the encryption and decryption.
   void genKeys() {
-    _c_gen_keys(backend.value, library);
+    _c_gen_keys(library);
     raiseForStatus();
   }
 
@@ -93,42 +92,41 @@ class Afhe {
   ///
   /// Requires the secret key to be generated first via genKeys().
   void genRelinKeys() {
-    _c_gen_relin_keys(backend.value, library);
+    _c_gen_relin_keys(library);
     raiseForStatus();
   }
 
   /// Encrypts the plaintext message.
   Ciphertext encrypt(Plaintext plaintext) {
-    final ptr = _c_encrypt(backend.value, library, plaintext.obj);
+    final ptr = _c_encrypt(library, plaintext.obj);
     raiseForStatus();
     return Ciphertext.fromPointer(backend, ptr);
   }
 
   /// Decrypts the ciphertext message.
   Plaintext decrypt(Ciphertext ciphertext) {
-    Pointer ptr = _c_decrypt(backend.value, library, ciphertext.obj);
+    Pointer ptr = _c_decrypt(library, ciphertext.obj);
     raiseForStatus();
     return Plaintext.fromPointer(backend, ptr);
   }
 
   /// Returns the invariant noise budget of the [Ciphertext].
   int invariantNoiseBudget(Ciphertext ciphertext) {
-    int n = _c_invariant_noise_budget(backend.value, library, ciphertext.obj);
+    int n = _c_invariant_noise_budget(library, ciphertext.obj);
     raiseForStatus();
     return n;
   }
 
   /// Encodes a list of integers into a [Plaintext].
   Plaintext encodeVecInt(List<int> vec) {
-    Pointer ptr = _c_encode_vector_int(
-        backend.value, library, intListToArray(vec), vec.length);
+    Pointer ptr = _c_encode_vector_int(library, intListToArray(vec), vec.length);
     raiseForStatus();
     return Plaintext.fromPointer(backend, ptr);
   }
 
   /// Decodes a [Plaintext] into a list of integers.
   List<int> decodeVecInt(Plaintext plaintext, int arrayLength) {
-    Pointer<Uint64> ptr = _c_decode_vector_int(backend.value, library, plaintext.obj);
+    Pointer<Uint64> ptr = _c_decode_vector_int(library, plaintext.obj);
     raiseForStatus();
     return arrayToIntList(ptr, arrayLength);
   }
@@ -138,28 +136,28 @@ class Afhe {
   /// Typically, the size of the ciphertext grows with each homomorphic operation.
   /// The relinearization process reduces the size of the ciphertext (2).
   Ciphertext relinearize(Ciphertext ciphertext) {
-    Pointer ptr = _c_relin_ciphertext(backend.value, library, ciphertext.obj);
+    Pointer ptr = _c_relin_ciphertext(library, ciphertext.obj);
     raiseForStatus();
     return Ciphertext.fromPointer(backend, ptr);
   }
 
   /// Modulus switches the [Ciphertext] to a next lower level.
   Ciphertext modSwitchNext(Ciphertext ciphertext) {
-    _c_mod_switch_next(backend.value, library, ciphertext.obj);
+    _c_mod_switch_next(library, ciphertext.obj);
     raiseForStatus();
     return ciphertext;
   }
 
   /// Adds two [Ciphertext]s.
   Ciphertext add(Ciphertext a, Ciphertext b) {
-    Pointer ptr = _c_add(backend.value, library, a.obj, b.obj);
+    Pointer ptr = _c_add(library, a.obj, b.obj);
     raiseForStatus();
     return Ciphertext.fromPointer(backend, ptr);
   }
 
   /// Adds value of [Plaintext] to the value of [Ciphertext].
   Ciphertext addPlain(Ciphertext a, Plaintext b) {
-    Pointer ptr = _c_add_plain(backend.value, library, a.obj, b.obj);
+    Pointer ptr = _c_add_plain(library, a.obj, b.obj);
     raiseForStatus();
     return Ciphertext.fromPointer(backend, ptr);
   }
@@ -168,7 +166,7 @@ class Afhe {
   ///
   /// Results in a new [Ciphertext] with the value of [a] minus the value of [b].
   Ciphertext subtract(Ciphertext a, Ciphertext b) {
-    Pointer ptr = _c_subtract(backend.value, library, a.obj, b.obj);
+    Pointer ptr = _c_subtract(library, a.obj, b.obj);
     raiseForStatus();
     return Ciphertext.fromPointer(backend, ptr);
   }
@@ -177,21 +175,21 @@ class Afhe {
   ///
   /// Results in a new [Ciphertext] with the value of [a] minus the value of [b].
   Ciphertext subtractPlain(Ciphertext a, Plaintext b) {
-    Pointer ptr = _c_subtract_plain(backend.value, library, a.obj, b.obj);
+    Pointer ptr = _c_subtract_plain(library, a.obj, b.obj);
     raiseForStatus();
     return Ciphertext.fromPointer(backend, ptr);
   }
 
   /// Multiplies two [Ciphertext]s.
   Ciphertext multiply(Ciphertext a, Ciphertext b) {
-    Pointer ptr = _c_multiply(backend.value, library, a.obj, b.obj);
+    Pointer ptr = _c_multiply(library, a.obj, b.obj);
     raiseForStatus();
     return Ciphertext.fromPointer(backend, ptr);
   }
 
   /// Multiplies a [Ciphertext] by a [Plaintext].
   Ciphertext multiplyPlain(Ciphertext a, Plaintext b) {
-    Pointer ptr = _c_multiply_plain(backend.value, library, a.obj, b.obj);
+    Pointer ptr = _c_multiply_plain(library, a.obj, b.obj);
     raiseForStatus();
     return Ciphertext.fromPointer(backend, ptr);
   }

--- a/dart/lib/afhe/ciphertext.dart
+++ b/dart/lib/afhe/ciphertext.dart
@@ -45,23 +45,18 @@ class Ciphertext {
 
 // --- noise budget ---
 
-typedef _InvariantNoiseBudgetC = Int32 Function(
-    BackendType backend, Pointer library, Pointer ciphertext);
-
-typedef _InvariantNoiseBudget = int Function(
-    int backend, Pointer library, Pointer ciphertext);
+typedef _InvariantNoiseBudgetC = Int32 Function(Pointer library, Pointer ciphertext);
+typedef _InvariantNoiseBudget = int Function(Pointer library, Pointer ciphertext);
 
 /// Returns the invariant noise budget of the ciphertext.
 final _InvariantNoiseBudget _c_invariant_noise_budget = dylib
     .lookup<NativeFunction<_InvariantNoiseBudgetC>>('invariant_noise_budget')
     .asFunction();
 
-typedef _ModSwitchNextC = Void Function(
-    BackendType backend, Pointer library, Pointer ciphertext);
+typedef _ModSwitchNextC = Void Function(Pointer library, Pointer ciphertext);
+typedef _ModSwitchNext = void Function(Pointer library, Pointer ciphertext);
 
-typedef _ModSwitchNext = void Function(
-    int backend, Pointer library, Pointer ciphertext);
-
+/// Modulus switches the ciphertext to the next level.
 final _ModSwitchNext _c_mod_switch_next = dylib
     .lookup<NativeFunction<_ModSwitchNextC>>('mod_switch_to_next')
     .asFunction();

--- a/dart/lib/afhe/codec.dart
+++ b/dart/lib/afhe/codec.dart
@@ -3,12 +3,10 @@ part of '../afhe.dart';
 
 // --- encode ---
 
-typedef _EncodeVectorIntC = Pointer Function(
-    BackendType backend, Pointer library, Pointer<Uint64> vec, Int size);
+typedef _EncodeVectorIntC = Pointer Function(Pointer library, Pointer<Uint64> vec, Int size);
+typedef _EncodeVectorInt = Pointer Function(Pointer library, Pointer<Uint64> vec, int size);
 
-typedef _EncodeVectorInt = Pointer Function(
-    int backend, Pointer library, Pointer<Uint64> vec, int size);
-
+/// Encodes a list of integers into a [Plaintext].
 final _EncodeVectorInt _c_encode_vector_int =
     dylib.lookupFunction<_EncodeVectorIntC, _EncodeVectorInt>('encode_int');
 
@@ -24,14 +22,11 @@ Pointer<Uint64> intListToArray(List<int> list) {
 
 // --- decode ---
 
-typedef _DecodeVectorIntC = Pointer<Uint64> Function(
-    BackendType backend, Pointer library, Pointer plaintext);
+typedef _DecodeVectorIntC = Pointer<Uint64> Function(Pointer library, Pointer plaintext);
 
-typedef _DecodeVectorInt = Pointer<Uint64> Function(
-    int backend, Pointer library, Pointer plaintext);
-
-final _DecodeVectorInt _c_decode_vector_int =
-    dylib.lookupFunction<_DecodeVectorIntC, _DecodeVectorInt>('decode_int');
+/// Decodes a [Plaintext] into a list of integers.
+final _DecodeVectorIntC _c_decode_vector_int = dylib
+    .lookupFunction<_DecodeVectorIntC, _DecodeVectorIntC>('decode_int');
 
 /// Convert C uint64 array to Dart int list.
 List<int> arrayToIntList(Pointer<Uint64> ptr, int length) {

--- a/dart/lib/afhe/crypto.dart
+++ b/dart/lib/afhe/crypto.dart
@@ -4,7 +4,6 @@ part of '../afhe.dart';
 // --- encryption parameters ---
 
 typedef _GenContextC = Pointer<Utf8> Function(
-    BackendType backend,
     Pointer library,
     Int32 scheme,
     Int64 poly_mod_degree,
@@ -12,55 +11,45 @@ typedef _GenContextC = Pointer<Utf8> Function(
     Int64 pt_mod,
     Int64 sec_level);
 
-typedef _GenContext = Pointer<Utf8> Function(int backend, Pointer library,
-    int scheme, int poly_mod_degree, int pt_mod_bit, int pt_mod, int sec_level);
+typedef _GenContext = Pointer<Utf8> Function(
+  Pointer library,
+  int scheme,
+  int poly_mod_degree,
+  int pt_mod_bit,
+  int pt_mod,
+  int sec_level);
 
-final _GenContext _c_gen_context =
-    dylib.lookup<NativeFunction<_GenContextC>>('generate_context').asFunction();
+final _GenContext _c_gen_context = dylib
+    .lookup<NativeFunction<_GenContextC>>('generate_context').asFunction();
 
 // --- encryption keys ---
 
-typedef _GenKeysC = Void Function(BackendType backend, Pointer library);
-typedef _GenKeys = void Function(int backend, Pointer library);
-
-final _GenKeys _c_gen_keys =
-    dylib.lookup<NativeFunction<_GenKeysC>>('generate_keys').asFunction();
+typedef _GenKeysC = Void Function(Pointer library);
+typedef _GenKeys = void Function(Pointer library);
+final _GenKeys _c_gen_keys = dylib
+    .lookup<NativeFunction<_GenKeysC>>('generate_keys').asFunction();
 
 // --- relinearization ---
 
-typedef _GenRelinKeysC = Void Function(BackendType backend, Pointer library);
-typedef _GenRelinKeys = void Function(int backend, Pointer library);
+typedef _GenRelinKeysC = Void Function(Pointer library);
+typedef _GenRelinKeys = void Function(Pointer library);
+final _GenRelinKeys _c_gen_relin_keys = dylib
+    .lookup<NativeFunction<_GenRelinKeysC>>('generate_relin_keys').asFunction();
 
-final _GenRelinKeys _c_gen_relin_keys =
-    dylib.lookup<NativeFunction<_GenRelinKeysC>>('generate_relin_keys').asFunction();
-
-typedef _RelinCiphertextC = Pointer Function(
-    BackendType backend, Pointer library, Pointer ciphertext);
-typedef _RelinCiphertext = Pointer Function(
-    int backend, Pointer library, Pointer ciphertext);
-
-final _RelinCiphertext _c_relin_ciphertext = dylib
+typedef _RelinCiphertextC = Pointer Function(Pointer library, Pointer ciphertext);
+final _RelinCiphertextC _c_relin_ciphertext = dylib
     .lookup<NativeFunction<_RelinCiphertextC>>('relinearize')
     .asFunction();
 
 // --- encrypt ---
 
-typedef _EncryptC = Pointer Function(
-    Int backend, Pointer library, Pointer plaintext);
-
-typedef _Encrypt = Pointer Function(
-    int backend, Pointer library, Pointer plaintext);
-
-final _Encrypt _c_encrypt =
-    dylib.lookup<NativeFunction<_EncryptC>>('encrypt').asFunction();
+typedef _EncryptC = Pointer Function(Pointer library, Pointer plaintext);
+final _EncryptC _c_encrypt = dylib
+    .lookup<NativeFunction<_EncryptC>>('encrypt').asFunction();
 
 // --- decrypt ---
 
-typedef _DecryptC = Pointer Function(
-    Int backend, Pointer library, Pointer plaintext);
+typedef _DecryptC = Pointer Function(Pointer library, Pointer plaintext);
 
-typedef _Decrypt = Pointer Function(
-    int backend, Pointer library, Pointer plaintext);
-
-final _Decrypt _c_decrypt =
-    dylib.lookup<NativeFunction<_EncryptC>>('decrypt').asFunction();
+final _DecryptC _c_decrypt = dylib
+    .lookup<NativeFunction<_DecryptC>>('decrypt').asFunction();

--- a/dart/lib/afhe/operation.dart
+++ b/dart/lib/afhe/operation.dart
@@ -3,48 +3,18 @@ part of '../afhe.dart';
 
 // --- add ---
 
-typedef _AddC = Pointer Function(
-    Int backend, Pointer library, Pointer ciphertext1, Pointer ciphertext2);
-
-typedef _Add = Pointer Function(
-    int backend, Pointer library, Pointer ciphertext1, Pointer ciphertext2);
-
-final _Add _c_add = dylib.lookup<NativeFunction<_AddC>>('add').asFunction();
-
-typedef _AddPlainC = Pointer Function(
-    Int backend, Pointer library, Pointer ciphertext, Pointer plaintext);
-
-typedef _AddPlain = Pointer Function(
-    int backend, Pointer library, Pointer ciphertext, Pointer plaintext);
-
-final _AddPlain _c_add_plain = dylib.lookup<NativeFunction<_AddPlainC>>('add_plain').asFunction();
+typedef _AddC = Pointer Function(Pointer library, Pointer a, Pointer b);
+final _AddC _c_add = dylib.lookup<NativeFunction<_AddC>>('add').asFunction();
+final _AddC _c_add_plain = dylib.lookup<NativeFunction<_AddC>>('add_plain').asFunction();
 
 // --- subtract ---
 
-typedef _SubC = Pointer Function(
-    Int backend, Pointer library, Pointer ciphertext1, Pointer ciphertext2);
-
-typedef _Sub = Pointer Function(
-    int backend, Pointer library, Pointer ciphertext1, Pointer ciphertext2);
-
-final _Sub _c_subtract = dylib.lookup<NativeFunction<_SubC>>('subtract').asFunction();
-
-typedef _SubPlainC = Pointer Function(
-    Int backend, Pointer library, Pointer ciphertext, Pointer plaintext);
-
-typedef _SubPlain = Pointer Function(
-    int backend, Pointer library, Pointer ciphertext, Pointer plaintext);
-
-final _SubPlain _c_subtract_plain = dylib.lookup<NativeFunction<_SubPlainC>>('subtract_plain').asFunction();
+typedef _SubC = Pointer Function(Pointer library, Pointer a, Pointer b);
+final _SubC _c_subtract = dylib.lookup<NativeFunction<_SubC>>('subtract').asFunction();
+final _SubC _c_subtract_plain = dylib.lookup<NativeFunction<_SubC>>('subtract_plain').asFunction();
 
 // --- multiply ---
 
-typedef _MultiplyC = Pointer Function(Int backend, Pointer library, Pointer ciphertext1, Pointer ciphertext2);
-typedef _Multiply = Pointer Function(int backend, Pointer library, Pointer ciphertext1, Pointer ciphertext2);
-
-final _Multiply _c_multiply = dylib.lookup<NativeFunction<_MultiplyC>>('multiply').asFunction();
-
-typedef _MultiplyPlainC = Pointer Function(Int backend, Pointer library, Pointer ciphertext, Pointer plaintext);
-typedef _MultiplyPlain = Pointer Function(int backend, Pointer library, Pointer ciphertext, Pointer plaintext);
-
-final _MultiplyPlain _c_multiply_plain = dylib.lookup<NativeFunction<_MultiplyPlainC>>('multiply_plain').asFunction();
+typedef _MultiplyC = Pointer Function(Pointer library, Pointer a, Pointer b);
+final _MultiplyC _c_multiply = dylib.lookup<NativeFunction<_MultiplyC>>('multiply').asFunction();
+final _MultiplyC _c_multiply_plain = dylib.lookup<NativeFunction<_MultiplyC>>('multiply_plain').asFunction();

--- a/dart/test/seal/error_test.dart
+++ b/dart/test/seal/error_test.dart
@@ -18,8 +18,8 @@ void main() {
   });
 
   test('Context is not initialized', () {
-    final seal = Afhe('seal', 'BFV');
-    expect(() => seal.encrypt(Plaintext(seal.backend)),
+    final seal = Seal('BFV');
+    expect(() => seal.genKeys(),
       throwsA(predicate((e) => e is Exception && e.toString() == 'Exception: Context is not initialized')));
   });
 

--- a/dart/test/seal/error_test.dart
+++ b/dart/test/seal/error_test.dart
@@ -4,24 +4,23 @@ import 'package:fhel/afhe.dart';
 
 void main() {
   test('Unsupported Backend', () {
+    expect(() => Afhe('', ''),
+      throwsA(predicate((e) => e is Exception && e.toString() == 'Exception: Unsupported Backend: null')));
     expect(() => Afhe('invalid', 'BFV'),
       throwsA(predicate((e) => e is Exception && e.toString() == 'Exception: Unsupported Backend: invalid')));
   });
 
   test('Unsupported Scheme', () {
+    expect(() => Seal(''),
+      throwsA(predicate((e) => e is Exception && e.toString() == 'Exception: Unsupported Scheme: null')));
     expect(() => Seal('invalid'),
       throwsA(predicate((e) => e is Exception && e.toString() == 'Exception: Unsupported Scheme: invalid')));
   });
 
   test('Context is not initialized', () {
-    final seal = Seal('BFV');
-    expect(() => seal.genKeys(),
+    final seal = Afhe('seal', 'BFV');
+    expect(() => seal.encrypt(Plaintext(seal.backend)),
       throwsA(predicate((e) => e is Exception && e.toString() == 'Exception: Context is not initialized')));
   });
 
-  test('No backend set', () {
-    var afhe = Afhe('', '');
-    expect(() => afhe.genKeys(),
-      throwsA(predicate((e) => e is Exception && e.toString() == 'Exception: [init_backend] No backend set')));
-  });
 }

--- a/dart/test/seal/plaintext_test.dart
+++ b/dart/test/seal/plaintext_test.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 import 'package:fhel/seal.dart' show Seal;
 
 void main() {
-  final fhe = Seal('');
+  final fhe = Seal('bfv'); // cannot exist without a scheme
 
   test('Default Constructor', () {
     final seal_pt = fhe.plain("");

--- a/include/afhe.h
+++ b/include/afhe.h
@@ -21,6 +21,17 @@ class Afhe;        /* Abstract Class */
 
 using namespace std;
 
+// ------------------ Backend Type ------------------
+/**
+ * @brief Enum for the supported backend libraries.
+ * @return Integer representing the backend library type.
+ */
+enum backend : int
+{
+  _none = 0,   /* No Backend Set */
+  _seal = 1,   /* Microsoft SEAL */
+};
+
 // ------------------ Scheme Type ------------------
 /**
  * @brief Enum for the scheme type.
@@ -35,27 +46,21 @@ enum scheme : int
 };
 
 /**
- * @brief Abstract Fully Homomorphic Encryption (AFHE) class.
- */
-class Afhe
-/**
- * @file afhe.h
- * @brief This file contains the declaration of the Afhe class, which represents a Fully Homomorphic Encryption (FHE) scheme.
- */
-
-/**
  * @class Afhe
  * @brief The Afhe class represents a Fully Homomorphic Encryption (FHE) scheme.
  *
  * This class provides methods for generating a context, managing keys, performing encryption and decryption operations,
  * encoding and decoding data, and performing arithmetic operations on ciphertexts.
  */
+class Afhe
 {
 public:
   // Class Management
   Afhe(){};
   // Destructor
   virtual ~Afhe(){};
+
+  backend backend_lib; /* The backend library to be used. */
 
   // ------------------ Parameters ------------------
   /**

--- a/include/backend/aseal.h
+++ b/include/backend/aseal.h
@@ -27,7 +27,6 @@
 #include "afhe.h"      /* Abstraction */
 
 using namespace std;
-using namespace seal;
 
 // Forward Declaration
 class Aseal;
@@ -37,14 +36,14 @@ class AsealPoly;
  * @brief Compression Modes used when compiling SEAL.
  */
 static map<string, seal::compr_mode_type> compr_mode_map {
-    {"none", compr_mode_type::none},
+    {"none", seal::compr_mode_type::none},
 #ifdef SEAL_USE_ZLIB
     // Use ZLIB compression
-    {"zlib", compr_mode_type::zlib},
+    {"zlib", seal::compr_mode_type::zlib},
 #endif
 #ifdef SEAL_USE_ZSTD
     // Use Zstandard compression
-    {"zstd", compr_mode_type::zstd},
+    {"zstd", seal::compr_mode_type::zstd},
 #endif
 };
 
@@ -63,7 +62,7 @@ static map<scheme, seal::scheme_type> scheme_map_to_seal {
 /**
  * @brief Security Levels
  */
-static map<int, sec_level_type> sec_map {
+static map<int, seal::sec_level_type> sec_map {
     {0, seal::sec_level_type::none},
     {128, seal::sec_level_type::tc128},
     {192, seal::sec_level_type::tc192},
@@ -138,12 +137,10 @@ private:
   shared_ptr<seal::Ciphertext> ciphertext;   /** Ciphertext.*/
 
 public:
-  vector<uint64_t> qi; /**< Vector of uint64_t values. */
-
   /**
    * @brief Default constructor for the Aseal class.
    */
-  Aseal(){};
+  Aseal(){ this->backend_lib = backend::_seal; };
 
   /**
    * @brief Copy constructor for the Aseal class.
@@ -179,7 +176,7 @@ public:
    * @return A pointer to the SEAL context object.
    * @throws std::logic_error if the context is not initialized.
   */
-  inline shared_ptr<SEALContext> get_context();
+  inline shared_ptr<seal::SEALContext> get_context();
 
   // ------------------ Keys ------------------
 

--- a/include/fhe.h
+++ b/include/fhe.h
@@ -26,8 +26,8 @@ extern "C" {
      */
     enum backend_t : int32_t
     {
-        no_t = 0,      /* No Library Set */
-        seal_t = 1,    /* Microsoft SEAL */
+        no_b = backend::_none,   /* No Backend Set */
+        seal_b = backend::_seal, /* Microsoft SEAL */
     };
 
     /**
@@ -43,6 +43,14 @@ extern "C" {
     };
 
 }
+
+/**
+ * @brief Map (abstract) backend type to backend_t
+*/
+static map<backend, backend_t> backend_map_backend_t{
+  {backend::_none, backend_t::no_b},
+  {backend::_seal, backend_t::seal_b},
+};
 
 /**
  * @brief Map scheme_t to (abstract) scheme type
@@ -66,7 +74,6 @@ struct cmp_str
  * @brief Map string to type for the supported schemes.
 */
 static map<const char*, scheme_t, cmp_str> scheme_t_map{
-  {"none", scheme_t::no_s},
   {"bfv", scheme_t::bfv_s},
   {"ckks", scheme_t::ckks_s},
   {"bgv", scheme_t::bgv_s},
@@ -76,8 +83,7 @@ static map<const char*, scheme_t, cmp_str> scheme_t_map{
  * @brief Map string to type for the supported backend libraries.
 */
 static map<const char*, backend_t, cmp_str> backend_t_map{
-  {"none", backend_t::no_t},
-  {"seal", backend_t::seal_t},
+  {"seal", backend_t::seal_b},
 };
 
 extern "C" {
@@ -115,7 +121,6 @@ extern "C" {
 
     /**
      * @brief Generate a context for the backend library.
-     * @param backend Backend library to use.
      * @param afhe Pointer to the backend library.
      * @param scheme Scheme to use.
      * @param poly_mod_degree Polynomial modulus degree.
@@ -124,21 +129,19 @@ extern "C" {
      * @param sec_level Security level.
      * @return String representing the context.
     */
-    const char* generate_context(backend_t backend, Afhe* afhe, scheme_t scheme, long poly_mod_degree, long pt_mod_bit, long pt_mod, long sec_level);
+    const char* generate_context(Afhe* afhe, scheme_t scheme, long poly_mod_degree, long pt_mod_bit, long pt_mod, long sec_level);
 
     /**
      * @brief Generate keys for the backend library.
-     * @param backend Backend library to use.
      * @param afhe Pointer to the backend library.
     */
-    void generate_keys(backend_t backend, Afhe* afhe);
+    void generate_keys(Afhe* afhe);
 
     /**
      * @brief Generate relinearization keys for the backend library.
-     * @param backend Backend library to use.
      * @param afhe Pointer to the backend library.
     */
-    void generate_relin_keys(backend_t backend, Afhe* afhe);
+    void generate_relin_keys(Afhe* afhe);
 
     /**
      * @brief Initialize the backend library.
@@ -185,110 +188,111 @@ extern "C" {
 
     /**
      * @brief Encrypt a plaintext.
-     * @param backend Backend library to use.
      * @param afhe Pointer to the backend library.
      * @param plaintext Pointer to the plaintext.
      * @return Pointer to the ciphertext.
     */
-    ACiphertext* encrypt(backend_t backend, Afhe* afhe, APlaintext* plaintext);
+    ACiphertext* encrypt(Afhe* afhe, APlaintext* plaintext);
 
     /**
      * @brief Decrypt a ciphertext.
-     * @param backend Backend library to use.
      * @param afhe Pointer to the backend library.
      * @param ciphertext Pointer to the ciphertext.
      * @return Pointer to the plaintext.
     */
-    APlaintext* decrypt(backend_t backend, Afhe* afhe, ACiphertext* ciphertext);
+    APlaintext* decrypt(Afhe* afhe, ACiphertext* ciphertext);
 
     /**
      * @brief Calculate the added noise to the ciphertext.
+     * @param afhe Pointer to the backend library.
+     * @param ciphertext Pointer to the ciphertext.
+     * @return Noise added to the ciphertext.
     */
-    int invariant_noise_budget(backend_t backend, Afhe* afhe, ACiphertext* ciphertext);
+    int invariant_noise_budget(Afhe* afhe, ACiphertext* ciphertext);
 
     /**
      * @brief Relinearize a ciphertext.
-     * @param backend Backend library to use.
      * @param afhe Pointer to the backend library.
      * @param ciphertext Pointer to the ciphertext.
      * @return Pointer to the relinearized ciphertext.
     */
-    ACiphertext* relinearize(backend_t backend, Afhe* afhe, ACiphertext* ciphertext);
+    ACiphertext* relinearize(Afhe* afhe, ACiphertext* ciphertext);
 
     /**
      * @brief Mod switch to the next level for a ciphertext.
-     * @param backend Backend library to use.
      * @param afhe Pointer to the backend library.
      * @param ciphertext Pointer to the ciphertext.
     */
-    void mod_switch_to_next(backend_t backend, Afhe* afhe, ACiphertext* ciphertext);
+    void mod_switch_to_next(Afhe* afhe, ACiphertext* ciphertext);
 
     /**
      * @brief Add two ciphertexts.
-     * @param backend Backend library to use.
-     * @param afhe Pointer to the backend library.
-    */
-    ACiphertext* add(backend_t backend, Afhe* afhe, ACiphertext* ciphertext1, ACiphertext* ciphertext2);
-
-    /**
-     * @brief Add a plaintext to a ciphertext.
-     * @param backend Backend library to use.
-     * @param afhe Pointer to the backend library.
-    */
-    ACiphertext* add_plain(backend_t backend, Afhe* afhe, ACiphertext* ciphertext, APlaintext* plaintext);
-
-    /**
-     * @brief Subtract two ciphertexts.
-     * @param backend Backend library to use.
-     * @param afhe Pointer to the backend library.
-    */
-    ACiphertext* subtract(backend_t backend, Afhe* afhe, ACiphertext* ciphertext1, ACiphertext* ciphertext2);
-
-
-    /**
-     * @brief Subtract a plaintext from a ciphertext.
-     * @param backend Backend library to use.
-     * @param afhe Pointer to the backend library.
-    */
-    ACiphertext* subtract_plain(backend_t backend, Afhe* afhe, ACiphertext* ciphertext, APlaintext* plaintext);
-
-    /**
-     * @brief Multiply two ciphertexts.
-     * @param backend Backend library to use.
      * @param afhe Pointer to the backend library.
      * @param ciphertext1 Pointer to the first ciphertext.
      * @param ciphertext2 Pointer to the second ciphertext.
      * @return Pointer to the resulting ciphertext.
     */
-    ACiphertext* multiply(backend_t backend, Afhe* afhe, ACiphertext* ciphertext1, ACiphertext* ciphertext2);
+    ACiphertext* add(Afhe* afhe, ACiphertext* ciphertext1, ACiphertext* ciphertext2);
 
     /**
-     * @brief Multiply a ciphertext by a plaintext.
-     * @param backend Backend library to use.
+     * @brief Add a plaintext to a ciphertext.
      * @param afhe Pointer to the backend library.
      * @param ciphertext Pointer to the ciphertext.
      * @param plaintext Pointer to the plaintext.
      * @return Pointer to the resulting ciphertext.
     */
-    ACiphertext* multiply_plain(backend_t backend, Afhe* afhe, ACiphertext* ciphertext, APlaintext* plaintext);
+    ACiphertext* add_plain(Afhe* afhe, ACiphertext* ciphertext, APlaintext* plaintext);
+
+    /**
+     * @brief Subtract two ciphertexts.
+     * @param afhe Pointer to the backend library.
+     * @param ciphertext1 Pointer to the first ciphertext.
+     * @param ciphertext2 Pointer to the second ciphertext.
+     * @return Pointer to the resulting ciphertext.
+    */
+    ACiphertext* subtract(Afhe* afhe, ACiphertext* ciphertext1, ACiphertext* ciphertext2);
+
+    /**
+     * @brief Subtract a plaintext from a ciphertext.
+     * @param afhe Pointer to the backend library.
+     * @param ciphertext Pointer to the ciphertext.
+     * @param plaintext Pointer to the plaintext.
+    */
+    ACiphertext* subtract_plain(Afhe* afhe, ACiphertext* ciphertext, APlaintext* plaintext);
+
+    /**
+     * @brief Multiply two ciphertexts.
+     * @param afhe Pointer to the backend library.
+     * @param ciphertext1 Pointer to the first ciphertext.
+     * @param ciphertext2 Pointer to the second ciphertext.
+     * @return Pointer to the resulting ciphertext.
+    */
+    ACiphertext* multiply(Afhe* afhe, ACiphertext* ciphertext1, ACiphertext* ciphertext2);
+
+    /**
+     * @brief Multiply a ciphertext by a plaintext.
+     * @param afhe Pointer to the backend library.
+     * @param ciphertext Pointer to the ciphertext.
+     * @param plaintext Pointer to the plaintext.
+     * @return Pointer to the resulting ciphertext.
+    */
+    ACiphertext* multiply_plain(Afhe* afhe, ACiphertext* ciphertext, APlaintext* plaintext);
 
     /**
      * @brief Encode a vector of integers into a plaintext.
-     * @param backend Backend library to use.
      * @param afhe Pointer to the backend library.
      * @param data Vector of integers to encode.
      * @return Pointer to the plaintext.
     */
-    APlaintext* encode_int(backend_t backend, Afhe* afhe, uint64_t* data, int len);
+    APlaintext* encode_int(Afhe* afhe, uint64_t* data, int len);
 
     /**
      * @brief Decode a plaintext into a vector of integers.
-     * @param backend Backend library to use.
      * @param afhe Pointer to the backend library.
      * @param plaintext Pointer to the plaintext.
      * @return Vector of integers.
     */
-    uint64_t* decode_int(backend_t backend, Afhe* afhe, APlaintext* plaintext);
+    uint64_t* decode_int(Afhe* afhe, APlaintext* plaintext);
 }
 
 #endif /* FHE_H */


### PR DESCRIPTION
When `Afhe` is present, use implemented `backend`
* Now supported within Afhe
* Validate backend, then scheme