### PR TITLE
CKKS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .svn/
 migrate_working_dir/
 Testing/
+.cache/
 
 # Dart
 pubspec.lock

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ if(DEFINED UNIT_TEST AND UNIT_TEST STREQUAL "ON")
         test/seal/subtraction.cpp
         test/seal/multiplication.cpp
         test/seal/relinearization.cpp
+        test/seal/ckks_basics.cpp
     )
 
     target_link_libraries(

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,12 @@ ctest:
 	@echo "Testing cpp..."
 	@cd $(AL_INSTALL_DIR); ctest
 
+# Debug Abstract Layer (AFHEL)
+.PHONY: ctest-debug
+ctest-debug:
+	@echo "Debugging cpp..."
+	@cd $(AL_INSTALL_DIR); ./seal_test
+
 # Test Implementation Layer (FHE)
 .PHONY: dtest
 dtest:

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ ctest:
 
 # Debug Abstract Layer (AFHEL)
 .PHONY: ctest-debug
-ctest-debug:
+ctest-debug: build-cmake
 	@echo "Debugging cpp..."
 	@cd $(AL_INSTALL_DIR); ./seal_test
 

--- a/dart/lib/afhe.dart
+++ b/dart/lib/afhe.dart
@@ -159,6 +159,7 @@ class Afhe {
   Plaintext encodeDouble(double value) {
     Pointer ptr = _c_encode_double(library, value);
     raiseForStatus();
+    // String cannot be extracted from C object for CKKS
     return Plaintext.fromPointer(backend, ptr, extractStr: false);
   }
 

--- a/dart/lib/afhe.dart
+++ b/dart/lib/afhe.dart
@@ -30,10 +30,12 @@ class Afhe {
   ///
   /// The [Scheme] is used to represent one of the supported fhe schemes.
   Scheme scheme = Scheme();
+
   /// The backend library used for the encryption scheme.
   ///
   /// The [Backend] is used to represent one of the supported fhe backends.
   Backend backend = Backend();
+
   /// A pointer to the memory address of the underlying C++ object.
   Pointer library = nullptr;
 
@@ -55,7 +57,8 @@ class Afhe {
         context['ptModBit'] ?? 0, // Only used when batching
         context['ptMod'] ?? 0, // Not used when batching
         context['secLevel'],
-        nullptr, 0);
+        nullptr,
+        0);
     raiseForStatus();
     return ptr.toDartString();
   }
@@ -85,7 +88,8 @@ class Afhe {
         context['encodeScalar'],
         0, // Plain Modulus is not used
         0, // Security Level is not used
-        intListToArray(primeSizes), primeSizes.length);
+        intListToUint64Array(primeSizes),
+        primeSizes.length);
     raiseForStatus();
     return ptr.toDartString();
   }
@@ -127,6 +131,7 @@ class Afhe {
   Plaintext decrypt(Ciphertext ciphertext) {
     Pointer ptr = _c_decrypt(library, ciphertext.obj);
     raiseForStatus();
+
     /// String cannot be extracted from C object
     if (scheme.name.toLowerCase() == "ckks") {
       return Plaintext.fromPointer(backend, ptr, extractStr: false);
@@ -143,7 +148,8 @@ class Afhe {
 
   /// Encodes a list of integers into a [Plaintext].
   Plaintext encodeVecInt(List<int> vec) {
-    Pointer ptr = _c_encode_vector_int(library, intListToUint64Array(vec), vec.length);
+    Pointer ptr =
+        _c_encode_vector_int(library, intListToUint64Array(vec), vec.length);
     raiseForStatus();
     return Plaintext.fromPointer(backend, ptr);
   }
@@ -165,7 +171,8 @@ class Afhe {
 
   /// Encodes a list of doubles into a [Plaintext].
   Plaintext encodeVecDouble(List<double> vec) {
-    Pointer ptr = _c_encode_vector_double(library, doubleListToArray(vec), vec.length);
+    Pointer ptr =
+        _c_encode_vector_double(library, doubleListToArray(vec), vec.length);
     raiseForStatus();
     // String cannot be extracted from C object for CKKS
     return Plaintext.fromPointer(backend, ptr, extractStr: false);

--- a/dart/lib/afhe.dart
+++ b/dart/lib/afhe.dart
@@ -85,7 +85,7 @@ class Afhe {
         context['encodeScalar'],
         0, // Plain Modulus is not used
         0, // Security Level is not used
-        intListToIntArray(primeSizes), primeSizes.length);
+        intListToArray(primeSizes), primeSizes.length);
     raiseForStatus();
     return ptr.toDartString();
   }
@@ -127,6 +127,10 @@ class Afhe {
   Plaintext decrypt(Ciphertext ciphertext) {
     Pointer ptr = _c_decrypt(library, ciphertext.obj);
     raiseForStatus();
+    /// String cannot be extracted from C object
+    if (scheme.name.toLowerCase() == "ckks") {
+      return Plaintext.fromPointer(backend, ptr, extractStr: false);
+    }
     return Plaintext.fromPointer(backend, ptr);
   }
 
@@ -148,7 +152,22 @@ class Afhe {
   List<int> decodeVecInt(Plaintext plaintext, int arrayLength) {
     Pointer<Uint64> ptr = _c_decode_vector_int(library, plaintext.obj);
     raiseForStatus();
-    return arrayToIntList(ptr, arrayLength);
+    return uint64ArrayToIntList(ptr, arrayLength);
+  }
+
+  /// Encodes a list of doubles into a [Plaintext].
+  Plaintext encodeVecDouble(List<double> vec) {
+    Pointer ptr = _c_encode_vector_double(library, doubleListToArray(vec), vec.length);
+    raiseForStatus();
+    // String cannot be extracted from C object for CKKS
+    return Plaintext.fromPointer(backend, ptr, extractStr: false);
+  }
+
+  /// Decodes a [Plaintext] into a list of doubles.
+  List<double> decodeVecDouble(Plaintext plaintext, int arrayLength) {
+    Pointer<Double> ptr = _c_decode_vector_double(library, plaintext.obj);
+    raiseForStatus();
+    return arrayToDoubleList(ptr, arrayLength);
   }
 
   /// Relinearizes the [Ciphertext].

--- a/dart/lib/afhe.dart
+++ b/dart/lib/afhe.dart
@@ -155,6 +155,13 @@ class Afhe {
     return uint64ArrayToIntList(ptr, arrayLength);
   }
 
+  /// Encodes a double into a [Plaintext].
+  Plaintext encodeDouble(double value) {
+    Pointer ptr = _c_encode_double(library, value);
+    raiseForStatus();
+    return Plaintext.fromPointer(backend, ptr, extractStr: false);
+  }
+
   /// Encodes a list of doubles into a [Plaintext].
   Plaintext encodeVecDouble(List<double> vec) {
     Pointer ptr = _c_encode_vector_double(library, doubleListToArray(vec), vec.length);

--- a/dart/lib/afhe/codec.dart
+++ b/dart/lib/afhe/codec.dart
@@ -20,7 +20,8 @@ Pointer<Uint64> intListToUint64Array(List<int> list) {
   return pointer;
 }
 
-Pointer<Int> intListToIntArray(List<int> list) {
+/// Convert Dart int list to C int array.
+Pointer<Int> intListToArray(List<int> list) {
   final length = list.length;
   final pointer = calloc<Int>(length + 1); // +1 if null-terminated.
   for (int index = 0; index < length; index++) {
@@ -55,7 +56,7 @@ final _DecodeVectorIntC _c_decode_vector_int = dylib
     .lookupFunction<_DecodeVectorIntC, _DecodeVectorIntC>('decode_int');
 
 /// Convert C uint64 array to Dart int list.
-List<int> arrayToIntList(Pointer<Uint64> ptr, int length) {
+List<int> uint64ArrayToIntList(Pointer<Uint64> ptr, int length) {
   final list = <int>[];
   for (var i = 0; i < length; i++) {
     list.add(ptr[i].toInt());

--- a/dart/lib/afhe/codec.dart
+++ b/dart/lib/afhe/codec.dart
@@ -7,13 +7,39 @@ typedef _EncodeVectorIntC = Pointer Function(Pointer library, Pointer<Uint64> ve
 typedef _EncodeVectorInt = Pointer Function(Pointer library, Pointer<Uint64> vec, int size);
 
 /// Encodes a list of integers into a [Plaintext].
-final _EncodeVectorInt _c_encode_vector_int =
-    dylib.lookupFunction<_EncodeVectorIntC, _EncodeVectorInt>('encode_int');
+final _EncodeVectorInt _c_encode_vector_int = dylib
+    .lookupFunction<_EncodeVectorIntC, _EncodeVectorInt>('encode_int');
 
 /// Convert Dart int list to C uint64 array.
-Pointer<Uint64> intListToArray(List<int> list) {
+Pointer<Uint64> intListToUint64Array(List<int> list) {
   final length = list.length;
   final pointer = calloc<Uint64>(length + 1); // +1 if null-terminated.
+  for (int index = 0; index < length; index++) {
+    pointer[index] = list[index];
+  }
+  return pointer;
+}
+
+Pointer<Int> intListToIntArray(List<int> list) {
+  final length = list.length;
+  final pointer = calloc<Int>(length + 1); // +1 if null-terminated.
+  for (int index = 0; index < length; index++) {
+    pointer[index] = list[index];
+  }
+  return pointer;
+}
+
+typedef _EncodeVectorDoubleC = Pointer Function(Pointer library, Pointer<Double> vec, Int size);
+typedef _EncodeVectorDouble = Pointer Function(Pointer library, Pointer<Double> vec, int size);
+
+/// Encodes a list of doubles into a [Plaintext].
+final _EncodeVectorDouble _c_encode_vector_double = dylib
+    .lookupFunction<_EncodeVectorDoubleC, _EncodeVectorDouble>('encode_double');
+
+/// Convert Dart double list to C double array.
+Pointer<Double> doubleListToArray(List<double> list) {
+  final length = list.length;
+  final pointer = calloc<Double>(length + 1); // +1 if null-terminated.
   for (int index = 0; index < length; index++) {
     pointer[index] = list[index];
   }
@@ -32,7 +58,22 @@ final _DecodeVectorIntC _c_decode_vector_int = dylib
 List<int> arrayToIntList(Pointer<Uint64> ptr, int length) {
   final list = <int>[];
   for (var i = 0; i < length; i++) {
-    list.add(ptr.elementAt(i).value);
+    list.add(ptr[i].toInt());
+  }
+  return list;
+}
+
+typedef _DecodeVectorDoubleC = Pointer<Double> Function(Pointer library, Pointer plaintext);
+
+/// Decodes a [Plaintext] into a list of doubles.
+final _DecodeVectorDoubleC _c_decode_vector_double = dylib
+    .lookupFunction<_DecodeVectorDoubleC, _DecodeVectorDoubleC>('decode_double');
+
+/// Convert C double array to Dart double list.
+List<double> arrayToDoubleList(Pointer<Double> ptr, int length) {
+  final list = <double>[];
+  for (var i = 0; i < length; i++) {
+    list.add(ptr[i].toDouble());
   }
   return list;
 }

--- a/dart/lib/afhe/codec.dart
+++ b/dart/lib/afhe/codec.dart
@@ -30,6 +30,13 @@ Pointer<Int> intListToArray(List<int> list) {
   return pointer;
 }
 
+typedef _EncodeDoubleC = Pointer Function(Pointer library, Double value);
+typedef _EncodeDouble = Pointer Function(Pointer library, double value);
+
+/// Encodes a double into a [Plaintext].
+final _EncodeDouble _c_encode_double = dylib
+    .lookupFunction<_EncodeDoubleC, _EncodeDouble>('encode_double_value');
+
 typedef _EncodeVectorDoubleC = Pointer Function(Pointer library, Pointer<Double> vec, Int size);
 typedef _EncodeVectorDouble = Pointer Function(Pointer library, Pointer<Double> vec, int size);
 

--- a/dart/lib/afhe/crypto.dart
+++ b/dart/lib/afhe/crypto.dart
@@ -6,12 +6,12 @@ part of '../afhe.dart';
 typedef _GenContextC = Pointer<Utf8> Function(
     Pointer library,
     Int32 scheme,
-    Int64 poly_mod_degree,
-    Int64 pt_mod_bit,
-    Int64 pt_mod,
-    Int64 sec_level,
-    Pointer<Int> prime_sizes,
-    Int prime_sizes_length);
+    Uint64 poly_mod_degree,
+    Uint64 pt_mod_bit,
+    Uint64 pt_mod,
+    Uint64 sec_level,
+    Pointer<Uint64> prime_sizes,
+    Uint64 prime_sizes_length);
 
 typedef _GenContext = Pointer<Utf8> Function(
   Pointer library,
@@ -20,7 +20,7 @@ typedef _GenContext = Pointer<Utf8> Function(
   int pt_mod_bit,
   int pt_mod,
   int sec_level,
-  Pointer<Int> prime_sizes,
+  Pointer<Uint64> prime_sizes,
   int prime_sizes_length);
 
 final _GenContext _c_gen_context = dylib

--- a/dart/lib/afhe/crypto.dart
+++ b/dart/lib/afhe/crypto.dart
@@ -9,7 +9,9 @@ typedef _GenContextC = Pointer<Utf8> Function(
     Int64 poly_mod_degree,
     Int64 pt_mod_bit,
     Int64 pt_mod,
-    Int64 sec_level);
+    Int64 sec_level,
+    Pointer<Int> prime_sizes,
+    Int prime_sizes_length);
 
 typedef _GenContext = Pointer<Utf8> Function(
   Pointer library,
@@ -17,7 +19,9 @@ typedef _GenContext = Pointer<Utf8> Function(
   int poly_mod_degree,
   int pt_mod_bit,
   int pt_mod,
-  int sec_level);
+  int sec_level,
+  Pointer<Int> prime_sizes,
+  int prime_sizes_length);
 
 final _GenContext _c_gen_context = dylib
     .lookup<NativeFunction<_GenContextC>>('generate_context').asFunction();

--- a/dart/lib/afhe/plaintext.dart
+++ b/dart/lib/afhe/plaintext.dart
@@ -45,7 +45,7 @@ class Plaintext {
 
   /// Initializes a plaintext from an existing C [obj].
   /// 
-  /// If [extract] is true, the string [obj] is extracted from the memory address.
+  /// If [extractStr] is true, the string [obj] is extracted from the memory address.
   Plaintext.fromPointer(this.backend, this.obj, {bool extractStr = true}) {
     if (extractStr)
     {

--- a/dart/lib/afhe/plaintext.dart
+++ b/dart/lib/afhe/plaintext.dart
@@ -44,7 +44,12 @@ class Plaintext {
   }
 
   /// Initializes a plaintext from an existing C [obj].
-  Plaintext.fromPointer(this.backend, this.obj) {
-    text = _c_get_plaintext(obj).toDartString();
+  /// 
+  /// If [extract] is true, the string [obj] is extracted from the memory address.
+  Plaintext.fromPointer(this.backend, this.obj, {bool extractStr = true}) {
+    if (extractStr)
+    {
+      text = _c_get_plaintext(obj).toDartString();
+    }
   }
 }

--- a/dart/test/seal/addition_test.dart
+++ b/dart/test/seal/addition_test.dart
@@ -1,6 +1,7 @@
 import 'package:test/test.dart';
 import 'package:fhel/seal.dart' show Seal;
 import 'test_utils.dart';
+import 'dart:math';
 
 const schemes = ['bgv', 'bfv'];
 
@@ -119,7 +120,7 @@ void main() {
     final fhe = Seal('ckks');
     Map ctx = {
       'polyModDegree': 8192,
-      'encodeScalar': 40,
+      'encodeScalar': pow(2, 40),
       'qSizes': [60, 40, 40, 60]
     };
     fhe.genContext(ctx);

--- a/dart/test/seal/addition_test.dart
+++ b/dart/test/seal/addition_test.dart
@@ -74,27 +74,6 @@ void main() {
     }
   });
 
-  // test('Double addition', () {
-  //   Map ctx = {
-  //     'polyModDegree': 8192,
-  //     'encodeScalar': 40,
-  //     'qSizes': [60, 40, 40, 60],
-  //   };
-
-  //   Seal fhe = Seal('ckks');
-  //   fhe.genContext(ctx);
-  //   fhe.genKeys();
-  //   var pt_x = fhe.plain('1.23');
-  //   var ct_x = fhe.encrypt(pt_x);
-
-  //   var pt_y = fhe.plain('2.46');
-  //   var ct_y = fhe.encrypt(pt_y);
-
-  //   var ct_res = fhe.add(ct_x, ct_y);
-  //   var pt_res = fhe.decrypt(ct_res);
-  //   expect(pt_res.text, '3.0');
-  // });
-
   test("List<int> Addition", () {
     for (var sch in schemes) {
       final fhe = Seal(sch);

--- a/dart/test/seal/context_test.dart
+++ b/dart/test/seal/context_test.dart
@@ -37,14 +37,36 @@ void main() {
     }
   });
 
-  test('CKKS not yet supported', () {
+  test('CKKS Required Parameters', () {
     final fhe = Seal('ckks');
     expect(
         () => fhe
-            .genContext({'polyModDegree': 4096, 'ptMod': 0, 'secLevel': 128}),
+            .genContext({'polyModDegree': 4096}),
         throwsA(predicate((e) =>
-            e is Exception &&
-            e.toString() == 'Exception: Unsupported scheme ckks')));
+            e is ArgumentError &&
+            e.message == 'encodeScalar is a required parameter for CKKS')));
+    expect(
+        () => fhe
+            .genContext({'polyModDegree': 4096, 'encodeScalar': 0}),
+        throwsA(predicate((e) =>
+            e is ArgumentError &&
+            e.message == 'qSizes is a required parameter for CKKS')));
+  });
+
+  test('Invalid qSizes', () {
+    final fhe = Seal('ckks');
+    expect(
+        () => fhe
+            .genContext({'polyModDegree': 4096, 'encodeScalar': 0, 'qSizes': 0}),
+        throwsA(predicate((e) =>
+            e is ArgumentError &&
+            e.message == 'qSizes must be a list of integers')));
+    expect(
+        () => fhe
+            .genContext({'polyModDegree': 4096, 'encodeScalar': 0, 'qSizes': []}),
+        throwsA(predicate((e) =>
+            e is ArgumentError &&
+            e.message == 'qSizes must be a list of integers')));
   });
 
   /* TODO: Security level is not checked during parameter validation */

--- a/dart/test/seal/multiplication_test.dart
+++ b/dart/test/seal/multiplication_test.dart
@@ -2,6 +2,7 @@ import 'package:fhel/afhe.dart';
 import 'package:test/test.dart';
 import 'package:fhel/seal.dart' show Seal;
 import 'test_utils.dart';
+import 'dart:math';
 
 const schemes = ['bgv', 'bfv'];
 
@@ -13,7 +14,8 @@ void modSwitchTest(Seal fhe, Ciphertext ct) {
   expect(beforeSwitch > afterSwitch, true);
 }
 
-Plaintext multiply(Seal fhe, Plaintext pt_x, Plaintext pt_m, {bool encryptMultiplier=true, bool modSwitch=true}) {
+Plaintext multiply(Seal fhe, Plaintext pt_x, Plaintext pt_m,
+    {bool encryptMultiplier = true, bool modSwitch = true}) {
   fhe.genKeys();
   final ct_x = fhe.encrypt(pt_x);
   Ciphertext ct_res;
@@ -25,13 +27,11 @@ Plaintext multiply(Seal fhe, Plaintext pt_x, Plaintext pt_m, {bool encryptMultip
     expect(ct_no_relin.size(), 3);
     ct_res = fhe.relinearize(ct_no_relin);
     expect(ct_res.size(), 2);
-  }
-  else {
+  } else {
     ct_res = fhe.multiplyPlain(ct_x, pt_m);
     expect(ct_res.size(), 2);
   }
-  if (modSwitch)
-  {
+  if (modSwitch) {
     modSwitchTest(fhe, ct_res);
   }
 
@@ -50,12 +50,13 @@ void main() {
       final pt_hex_10 = fhe.plain(10.toRadixString(16));
       String status = fhe.genContext(ctx);
       expect(status, 'success: valid');
+      expect(100.toRadixString(16),
+          multiply(fhe, pt_hex_10, pt_hex_10).text.toLowerCase());
       expect(
-        100.toRadixString(16),
-        multiply(fhe, pt_hex_10, pt_hex_10).text.toLowerCase());
-      expect(
-        100.toRadixString(16),
-        multiply(fhe, pt_hex_10, pt_hex_10, encryptMultiplier: false).text.toLowerCase());
+          100.toRadixString(16),
+          multiply(fhe, pt_hex_10, pt_hex_10, encryptMultiplier: false)
+              .text
+              .toLowerCase());
     }
   });
 
@@ -78,14 +79,17 @@ void main() {
       final pt_m = fhe.encodeVecInt(m);
 
       expect(product, fhe.decodeVecInt(multiply(fhe, pt_x, pt_m), arr_len));
-      expect(product, fhe.decodeVecInt(multiply(fhe, pt_x, pt_m, encryptMultiplier: false), arr_len));
+      expect(
+          product,
+          fhe.decodeVecInt(
+              multiply(fhe, pt_x, pt_m, encryptMultiplier: false), arr_len));
     }
   });
 
   test("List<double> Multiplication", () {
     Map ctx = {
       'polyModDegree': 8192,
-      'encodeScalar': 40,
+      'encodeScalar': pow(2, 40),
       'qSizes': [60, 40, 40, 60]
     };
     List<double> x = [1.1, 2.2, 3.3, 4.4];
@@ -100,13 +104,17 @@ void main() {
     final pt_m = fhe.encodeVecDouble(m);
 
     for (int i = 0; i < arr_len; i++) {
-      near(eps: 1e-7, product[i],
-           fhe.decodeVecDouble(
-              multiply(fhe, pt_x, pt_m, modSwitch: false),
-              arr_len)[i]);
-      near(eps: 1e-7, product[i],
-           fhe.decodeVecDouble(
-              multiply(fhe, pt_x, pt_m, modSwitch: false, encryptMultiplier: false),
+      near(
+          eps: 1e-7,
+          product[i],
+          fhe.decodeVecDouble(
+              multiply(fhe, pt_x, pt_m, modSwitch: false), arr_len)[i]);
+      near(
+          eps: 1e-7,
+          product[i],
+          fhe.decodeVecDouble(
+              multiply(fhe, pt_x, pt_m,
+                  modSwitch: false, encryptMultiplier: false),
               arr_len)[i]);
     }
   });
@@ -114,7 +122,7 @@ void main() {
   test("List<double> Pi * x^2", () {
     Map ctx = {
       'polyModDegree': 8192,
-      'encodeScalar': 40,
+      'encodeScalar': pow(2, 40),
       'qSizes': [60, 40, 40, 60]
     };
     List<double> x = [1.1, 2.2, 3.3, 4.4];
@@ -137,12 +145,21 @@ void main() {
     Ciphertext ct_pi_squared = fhe.multiplyPlain(ct_squared_relin, pt_pi);
     Plaintext pt_pi_squared = fhe.decrypt(ct_pi_squared);
 
-    List<double> product = [3.801327107, 15.205308426, 34.211943958, 60.821233704];
+    List<double> product = [
+      3.801327107,
+      15.205308426,
+      34.211943958,
+      60.821233704
+    ];
     for (int i = 0; i < arr_len; i++) {
-      near(eps: 1e-7, product[i],
-           fhe.decodeVecDouble(pt_pi_squared, arr_len)[i]);
-      near(eps: 1e-7, product[i],
-           fhe.decodeVecDouble(pt_pi_squared, arr_len)[i]);
+      near(
+          eps: 1e-7,
+          product[i],
+          fhe.decodeVecDouble(pt_pi_squared, arr_len)[i]);
+      near(
+          eps: 1e-7,
+          product[i],
+          fhe.decodeVecDouble(pt_pi_squared, arr_len)[i]);
     }
   });
 }

--- a/dart/test/seal/subtraction_test.dart
+++ b/dart/test/seal/subtraction_test.dart
@@ -1,10 +1,12 @@
 import 'package:test/test.dart';
 import 'package:fhel/seal.dart' show Seal;
 import 'test_utils.dart';
+import 'dart:math';
 
 const schemes = ['bgv', 'bfv'];
 
-String sub(String scheme, String a, String b, Map<String, int> ctx, {bool encryptSubtrahend = true}) {
+String sub(String scheme, String a, String b, Map<String, int> ctx,
+    {bool encryptSubtrahend = true}) {
   final fhe = Seal(scheme);
   String status = fhe.genContext(ctx);
   expect(status, 'success: valid');
@@ -45,12 +47,12 @@ void main() {
     };
 
     for (var sch in schemes) {
+      expect(120.toRadixString(16),
+          sub(sch, 200.toRadixString(16), 80.toRadixString(16), ctx));
       expect(
-        120.toRadixString(16),
-        sub(sch, 200.toRadixString(16), 80.toRadixString(16), ctx));
-      expect(
-        120.toRadixString(16),
-        sub(sch, 200.toRadixString(16), 80.toRadixString(16), ctx, encryptSubtrahend: false));
+          120.toRadixString(16),
+          sub(sch, 200.toRadixString(16), 80.toRadixString(16), ctx,
+              encryptSubtrahend: false));
     }
 
     // Otherwise, you are forced to increase plaintext modulus,
@@ -64,12 +66,12 @@ void main() {
     // When using hexadecimal, plain modulus can be lower
     ctx['ptMod'] = 4196;
     for (var sch in schemes) {
+      expect(1200.toRadixString(16).toLowerCase(),
+          sub(sch, 2000.toRadixString(16), 800.toRadixString(16), ctx));
       expect(
-        1200.toRadixString(16).toLowerCase(),
-        sub(sch, 2000.toRadixString(16), 800.toRadixString(16), ctx));
-      expect(
-        1200.toRadixString(16).toLowerCase(),
-        sub(sch, 2000.toRadixString(16), 800.toRadixString(16), ctx, encryptSubtrahend: false));
+          1200.toRadixString(16).toLowerCase(),
+          sub(sch, 2000.toRadixString(16), 800.toRadixString(16), ctx,
+              encryptSubtrahend: false));
     }
   });
 
@@ -107,11 +109,11 @@ void main() {
     }
   });
 
-   test("List<double> Subtraction", () {
+  test("List<double> Subtraction", () {
     final fhe = Seal('ckks');
     Map ctx = {
       'polyModDegree': 8192,
-      'encodeScalar': 40,
+      'encodeScalar': pow(2, 40),
       'qSizes': [60, 40, 40, 60]
     };
     fhe.genContext(ctx);
@@ -145,5 +147,4 @@ void main() {
       near(actual_cipher[i], expected[i], eps: 1e-7);
     }
   });
-
 }

--- a/dart/test/seal/test_utils.dart
+++ b/dart/test/seal/test_utils.dart
@@ -1,0 +1,16 @@
+import 'package:test/test.dart';
+
+/// Asserts that [a] and [b] are nearly equal.
+/// 
+/// The optional parameter [eps] is the maximum difference between [a] and [b].
+/// The optional parameter [relative] is whether to use relative or absolute difference.
+/// 
+void near(double a, double b, {double eps = 1e-12, bool relative = false}) {
+    var bound = relative ? eps*b.abs() : eps;
+    if (a == b) {
+      expect(a, b);
+    } else {
+      expect(a, greaterThanOrEqualTo(b-bound));
+      expect(a, lessThanOrEqualTo(b+bound));
+    }
+}

--- a/include/afhe.h
+++ b/include/afhe.h
@@ -70,18 +70,17 @@ public:
    *
    * @param scheme The encryption scheme to be used.
    * @param poly_modulus_degree The degree of the polynomial modulus, which determines the size and performance of the FHE operations.
-   * @param plain_modulus_bit_size The bit size of the plaintext modulus.
+   * @param plain_modulus_bit_size The bit size of the plaintext modulus / CKKS encoder scale.
    * @param plain_modulus The plaintext modulus, which affects the precision of the computations.
    * @param sec_level The security level, which affects the hardness of the cryptographic problem underlying the FHE scheme.
    * @param qi_sizes (optional) A vector of sizes for each modulus in the modulus chain.
-   * @param qi_mods (optional) A vector of specific moduli for the modulus chain.
    *
    * @return A string representing the status of generated context.
    */
   virtual string ContextGen(
     scheme scheme, uint64_t poly_modulus_degree,
     uint64_t plain_modulus_bit_size, uint64_t plain_modulus,
-    int sec_level, vector<int> qi_sizes = {}, vector<uint64_t> qi_mods = {}) = 0;
+    int sec_level, vector<int> qi_sizes = {}) = 0;
 
   // virtual vector<uint64_t> get_qi() = 0;
   // virtual uint64_t get_plain_modulus() = 0;
@@ -155,6 +154,11 @@ public:
   // ------------------ Codec ------------------
 
   /**
+   * @brief Returns the number of plaintext slots in an encoded ciphertext.
+  */
+  virtual int slot_count() = 0;
+
+  /**
    * @brief Encodes a vector of integers into a plaintext message.
    *        Used by BGV and BFV schemes.
    *
@@ -170,7 +174,7 @@ public:
    * @param data The vector of floats to be encoded.
    * @param ptxt The plaintext message where the encoded message will be stored.
    */
-  // virtual void encode_float(vector<double> &data, APlainTxt &ptxt) = 0;
+  virtual void encode_double(vector<double> &data, APlaintext &ptxt) = 0;
 
   /**
    * @brief Encodes a vector of complex numbers into a plaintext message.
@@ -197,7 +201,7 @@ public:
    * @param ptxt The plaintext message to be decoded.
    * @param data The vector of floats where the decoded message will be stored.
    */
-  // virtual void decode_float(APlainTxt &ptxt, vector<double> &data) = 0;
+  virtual void decode_double(APlaintext &ptxt, vector<double> &data) = 0;
 
   /**
    * @brief Decodes a plaintext message into a vector of complex numbers.

--- a/include/afhe.h
+++ b/include/afhe.h
@@ -177,6 +177,15 @@ public:
   virtual void encode_double(vector<double> &data, APlaintext &ptxt) = 0;
 
   /**
+   * @brief Encodes a single double into a plaintext message.
+   *        Used by CKKS scheme.
+   *
+   * @param data The double to be encoded.
+   * @param ptxt The plaintext message where the encoded message will be stored.
+   */
+  virtual void encode_double(double data, APlaintext &ptxt) = 0;
+
+  /**
    * @brief Encodes a vector of complex numbers into a plaintext message.
    *        Used by CKKS scheme.
    *

--- a/include/afhe.h
+++ b/include/afhe.h
@@ -107,7 +107,7 @@ public:
   /**
    * @brief Reduces the size of a ciphertext.
    *
-   * This is a technique to reduce the size of the ciphertext typically 
+   * This is a technique to reduce the size of the ciphertext typically
    * called when ciphertext.size() > 2. Results in a ciphertext.size() == 2.
    *
    * @param ctxt The ciphertext to be relinearized, inplace.
@@ -115,14 +115,34 @@ public:
   virtual void relinearize(ACiphertext &ctxt) = 0;
 
   /**
+   * @brief Reduces the noise in a plaintext.
+   *
+   * Modulus switches an NTT transformed plaintext to the next modulus in the modulus chain.
+   *
+   * @param ptxt The plaintext to be mod switched, inplace.
+   */
+  virtual void mod_switch_to_next(APlaintext &ptxt) = 0;
+
+  /**
    * @brief Reduces the noise in a ciphertext.
-   * 
+   *
    * `Modulus switching' is a technique of changing the ciphertext parameters down
    *  in the chain. This is done to reduce the noise in the ciphertext.
-   * 
+   *
    * @param ctxt The ciphertext to be mod switched, inplace.
    */
   virtual void mod_switch_to_next(ACiphertext &ctxt) = 0;
+
+  /**
+   * @brief Adjusts the scale of an encoded ciphertext in the CKKS scheme.
+   *
+   * `Rescaling' is a technique specific to the CKKS scheme that adjusts the scale of a ciphertext to enable
+   * proper decryption and homomorphic operations at a new scale. It effectively divides the ciphertext by the last modulus
+   * in the modulus chain and removes that modulus, thus reducing the scale and the modulus chain length.
+   *
+   * @param ctxt The ciphertext to be rescaled, inplace.
+  */
+  virtual void rescale_to_next(ACiphertext &ctxt) = 0;
 
   // virtual string get_secret_key() = 0;
   // virtual string get_public_key() = 0;
@@ -300,6 +320,8 @@ class ACiphertext{
 public:
   virtual ~ACiphertext() = default;
   virtual size_t size() = 0;
+  virtual double scale() = 0;
+  virtual void set_scale(double scale) = 0;
 };
 
 #endif /* AFHE_H */

--- a/include/afhe.h
+++ b/include/afhe.h
@@ -73,7 +73,7 @@ public:
    * @param plain_modulus_bit_size The bit size of the plaintext modulus / CKKS encoder scale.
    * @param plain_modulus The plaintext modulus, which affects the precision of the computations.
    * @param sec_level The security level, which affects the hardness of the cryptographic problem underlying the FHE scheme.
-   * @param qi_sizes (optional) A vector of sizes for each modulus in the modulus chain.
+   * @param qi_sizes (optional) A vector of prime bit sizes for each modulus in the modulus chain.
    *
    * @return A string representing the status of generated context.
    */

--- a/include/afhe.h
+++ b/include/afhe.h
@@ -115,6 +115,16 @@ public:
   virtual void relinearize(ACiphertext &ctxt) = 0;
 
   /**
+   * @brief Modulus switches a plaintext using a given parameter id.
+  */
+  virtual void mod_switch_to(APlaintext &ptxt, ACiphertext &ctxt) = 0;
+
+  /**
+   * @brief Modulus switches a ciphertext using a given parameter id.
+  */
+  virtual void mod_switch_to(ACiphertext &to, ACiphertext &from) = 0;
+
+  /**
    * @brief Reduces the noise in a plaintext.
    *
    * Modulus switches an NTT transformed plaintext to the next modulus in the modulus chain.

--- a/include/backend/aseal.h
+++ b/include/backend/aseal.h
@@ -123,8 +123,9 @@ inline AsealCiphertext& _to_ciphertext(ACiphertext& c){
 class Aseal : public Afhe {
 private:
   shared_ptr<seal::SEALContext> context;     /**< Pointer to the SEAL context object. */
-  shared_ptr<seal::BatchEncoder> encoder;    /**< Pointer to the BatchEncoder object. */
-
+  shared_ptr<seal::BatchEncoder> bEncoder;   /**< Pointer to the BatchEncoder object. */
+  shared_ptr<seal::CKKSEncoder> cEncoder;    /**< Pointer to the CKKSEncoder object. */
+  double cEncoderScale;                      /**< Scale for CKKSEncoder. */
   shared_ptr<seal::KeyGenerator> keyGenObj;  /** Key generator.*/
   shared_ptr<seal::SecretKey> secretKey;     /** Secret key.*/
   shared_ptr<seal::PublicKey> publicKey;     /** Public key.*/
@@ -170,7 +171,7 @@ public:
   string ContextGen(
     scheme scheme, uint64_t poly_modulus_degree = 1024,
     uint64_t plain_modulus_bit_size = 0, uint64_t plain_modulus = 0,
-    int sec_level = 128, vector<int> qi_sizes = {}, vector<uint64_t> qi_values = {}) override;
+    int sec_level = 128, vector<int> qi_sizes = {}) override;
 
   /**
    * @return A pointer to the SEAL context object.
@@ -198,8 +199,13 @@ public:
 
   // -------------------- Codec --------------------
 
+  int slot_count() override;
+
   void encode_int(vector<uint64_t> &data, APlaintext &ptxt) override;
   void decode_int(APlaintext &ptxt, vector<uint64_t> &data) override;
+
+  void encode_double(vector<double> &data, APlaintext &ptxt) override;
+  void decode_double(APlaintext &ptxt, vector<double> &data) override;
 
   // ------------------ Arithmetic ------------------
 

--- a/include/backend/aseal.h
+++ b/include/backend/aseal.h
@@ -204,6 +204,7 @@ public:
   void encode_int(vector<uint64_t> &data, APlaintext &ptxt) override;
   void decode_int(APlaintext &ptxt, vector<uint64_t> &data) override;
 
+  void encode_double(double data, APlaintext &ptxt) override;
   void encode_double(vector<double> &data, APlaintext &ptxt) override;
   void decode_double(APlaintext &ptxt, vector<double> &data) override;
 

--- a/include/backend/aseal.h
+++ b/include/backend/aseal.h
@@ -183,13 +183,21 @@ public:
    * @return A pointer to the SEAL context object.
    * @throws std::logic_error if the context is not initialized.
   */
-  inline shared_ptr<seal::SEALContext> get_context();
+  inline shared_ptr<seal::SEALContext> get_context() {
+    if (this->context == nullptr)
+    {
+      throw logic_error("Context is not initialized");
+    }
+    return this->context;
+  }
 
   // ------------------ Keys ------------------
 
   void KeyGen() override;
   void RelinKeyGen() override;
   void relinearize(ACiphertext &ctxt) override;
+  void mod_switch_to(APlaintext &ptxt, ACiphertext &ctxt) override;
+  void mod_switch_to(ACiphertext &to, ACiphertext &from) override;
   void mod_switch_to_next(APlaintext &ptxt) override;
   void mod_switch_to_next(ACiphertext &ctxt) override;
   void rescale_to_next(ACiphertext &ctxt) override;

--- a/include/backend/aseal.h
+++ b/include/backend/aseal.h
@@ -110,6 +110,12 @@ public:
   size_t size() override {
     return seal::Ciphertext::size();
   }
+  double scale() override {
+    return seal::Ciphertext::scale();
+  }
+  void set_scale(double scale) override {
+    seal::Ciphertext::scale() = scale;
+  }
 };
 
 // DYNAMIC CASTING
@@ -184,7 +190,9 @@ public:
   void KeyGen() override;
   void RelinKeyGen() override;
   void relinearize(ACiphertext &ctxt) override;
+  void mod_switch_to_next(APlaintext &ptxt) override;
   void mod_switch_to_next(ACiphertext &ctxt) override;
+  void rescale_to_next(ACiphertext &ctxt) override;
   // string get_secret_key() override;
   // string get_public_key() override;
 

--- a/include/fhe.h
+++ b/include/fhe.h
@@ -305,6 +305,14 @@ extern "C" {
     APlaintext* encode_double(Afhe* afhe, double* data, int len);
 
     /**
+     * @brief Encode a double into a plaintext.
+     * @param afhe Pointer to the backend library.
+     * @param data Double to encode.
+     * @return Pointer to the plaintext.
+    */
+    APlaintext* encode_double_value(Afhe* afhe, double data);
+
+    /**
      * @brief Decode a plaintext into a vector of doubles.
      * @param afhe Pointer to the backend library.
      * @param plaintext Pointer to the plaintext.

--- a/include/fhe.h
+++ b/include/fhe.h
@@ -127,9 +127,11 @@ extern "C" {
      * @param pt_mod_bit Plaintext modulus bit size.
      * @param pt_mod Plaintext modulus.
      * @param sec_level Security level.
+     * @param qi_sizes Array of primes for the coefficient modulus.
+     * @param qi_sizes_length Length of the array of primes.
      * @return String representing the context.
     */
-    const char* generate_context(Afhe* afhe, scheme_t scheme, long poly_mod_degree, long pt_mod_bit, long pt_mod, long sec_level);
+    const char* generate_context(Afhe* afhe, scheme_t scheme, int poly_mod_degree, int pt_mod_bit, int pt_mod, int sec_level, const int* qi_sizes, int qi_sizes_length);
 
     /**
      * @brief Generate keys for the backend library.
@@ -293,6 +295,22 @@ extern "C" {
      * @return Vector of integers.
     */
     uint64_t* decode_int(Afhe* afhe, APlaintext* plaintext);
+
+    /**
+     * @brief Encode a vector of doubles into a plaintext.
+     * @param afhe Pointer to the backend library.
+     * @param data Vector of doubles to encode.
+     * @return Pointer to the plaintext.
+    */
+    APlaintext* encode_double(Afhe* afhe, double* data, int len);
+
+    /**
+     * @brief Decode a plaintext into a vector of doubles.
+     * @param afhe Pointer to the backend library.
+     * @param plaintext Pointer to the plaintext.
+     * @return Vector of doubles.
+    */
+    double* decode_double(Afhe* afhe, APlaintext* plaintext);
 }
 
 #endif /* FHE_H */

--- a/include/fhe.h
+++ b/include/fhe.h
@@ -131,7 +131,7 @@ extern "C" {
      * @param qi_sizes_length Length of the array of primes.
      * @return String representing the context.
     */
-    const char* generate_context(Afhe* afhe, scheme_t scheme, int poly_mod_degree, int pt_mod_bit, int pt_mod, int sec_level, const int* qi_sizes, int qi_sizes_length);
+    const char* generate_context(Afhe* afhe, scheme_t scheme, uint64_t poly_mod_degree, uint64_t pt_mod_bit, uint64_t pt_mod, uint64_t sec_level, const uint64_t* qi_sizes, uint64_t qi_sizes_length);
 
     /**
      * @brief Generate keys for the backend library.

--- a/src/backend/aseal.cpp
+++ b/src/backend/aseal.cpp
@@ -10,6 +10,7 @@
 */
 
 #include "aseal.h"
+#include "afhe.h"
 
 using namespace std;
 using namespace seal;
@@ -70,7 +71,7 @@ string Aseal::ContextGen(scheme scheme,
     param.set_coeff_modulus(CoeffModulus::Create(poly_modulus_degree, bit_sizes));
 
     // Set CKKS Encoder scale
-    this->cEncoderScale = pow(2.0, plain_modulus_bit_size);
+    this->cEncoderScale = plain_modulus_bit_size; //pow(2.0, plain_modulus_bit_size);
   }
 
   // Validate parameters by putting them inside a SEALContext
@@ -168,6 +169,30 @@ void Aseal::mod_switch_to_next(ACiphertext &ctxt)
 
   // Mod Switch using casted types
   this->evaluator->mod_switch_to_next_inplace(_to_ciphertext(ctxt));
+}
+
+void Aseal::mod_switch_to_next(APlaintext &ptxt)
+{
+  // Gather current context, resolves object
+  auto &seal_context = *(this->get_context());
+
+  // Initialize Evaluator object
+  this->evaluator = make_shared<Evaluator>(seal_context);
+
+  // Mod Switch using casted types
+  this->evaluator->mod_switch_to_next_inplace(_to_plaintext(ptxt));
+}
+
+void Aseal::rescale_to_next(ACiphertext &ctxt)
+{
+  // Gather current context, resolves object
+  auto &seal_context = *(this->get_context());
+
+  // Initialize Evaluator object
+  this->evaluator = make_shared<Evaluator>(seal_context);
+
+  // Rescale using casted types
+  this->evaluator->rescale_to_next_inplace(_to_ciphertext(ctxt));
 }
 
 // string Aseal::get_secret_key()

--- a/src/backend/aseal.cpp
+++ b/src/backend/aseal.cpp
@@ -21,11 +21,10 @@ string Aseal::ContextGen(scheme scheme,
                          uint64_t plain_modulus_bit_size,
                          uint64_t plain_modulus,
                          int sec_level,
-                         vector<int> qi_sizes,
-                         vector<uint64_t> qi_values)
+                         vector<int> qi_sizes)
 { try {
-  // Initialize parameters
-  EncryptionParameters param(scheme_map_to_seal[scheme]);
+  // Initialize parameters with scheme
+  EncryptionParameters param(scheme_map_to_seal.at(scheme));
 
   /*
    * BGV encodes plaintext with “least significant bits”
@@ -52,8 +51,38 @@ string Aseal::ContextGen(scheme scheme,
       param.set_plain_modulus(plain_modulus);
     }
   }
+  else if (scheme == scheme::ckks)
+  {
+    // Set polynomial modulus degree
+    param.set_poly_modulus_degree(poly_modulus_degree);
+
+    if (qi_sizes.size() == 0)
+    {
+      throw invalid_argument("CKKS requires at least one qi_size");
+    }
+
+    // Set coefficient modulus
+    param.set_coeff_modulus(CoeffModulus::Create(poly_modulus_degree, qi_sizes));
+
+    // Set CKKS Encoder scale
+    this->cEncoderScale = pow(2.0, plain_modulus_bit_size);
+  }
+
   // Validate parameters by putting them inside a SEALContext
   this->context = make_shared<SEALContext>(param, true, sec_map[sec_level]);
+
+  // Initialize Encoder object
+  if(this->context->parameters_set() && plain_modulus_bit_size > 0)
+  {
+    if (scheme == scheme::bfv || scheme == scheme::bgv)
+    {
+      this->bEncoder = make_shared<BatchEncoder>(*this->context);
+    }
+    else if (scheme == scheme::ckks)
+    {
+      this->cEncoder = make_shared<CKKSEncoder>(*this->context);
+    }
+  }
 
   // Return info about parameter validity.
   //    - 'success: valid' if everything went well
@@ -181,16 +210,30 @@ int Aseal::invariant_noise_budget(ACiphertext &ctxt)
   return this->decryptor->invariant_noise_budget(_to_ciphertext(ctxt));
 }
 
+int Aseal::slot_count()
+{
+  // Gather current context, resolves object
+  auto &seal_context = *(this->get_context());
+
+  if (this->bEncoder != nullptr) {
+    return this->bEncoder->slot_count();
+  }
+  else if (this->cEncoder != nullptr) {
+    return this->cEncoder->slot_count();
+  }
+  throw logic_error("Encoder is not initialized");
+}
+
 void Aseal::encode_int(vector<uint64_t> &data, APlaintext &ptxt)
 {
   // Gather current context, resolves object
   auto &seal_context = *(this->get_context());
 
   // Initialize Encoder object
-  this->encoder = make_shared<BatchEncoder>(seal_context);
+  // this->bEncoder = make_shared<BatchEncoder>(seal_context);
 
   // Encode using casted types
-  this->encoder->encode(data, _to_plaintext(ptxt));
+  this->bEncoder->encode(data, _to_plaintext(ptxt));
 }
 
 void Aseal::decode_int(APlaintext &ptxt, vector<uint64_t> &data)
@@ -199,10 +242,34 @@ void Aseal::decode_int(APlaintext &ptxt, vector<uint64_t> &data)
   auto &seal_context = *(this->get_context());
 
   // Initialize Encoder object
-  this->encoder = make_shared<BatchEncoder>(seal_context);
+  // this->bEncoder = make_shared<BatchEncoder>(seal_context);
 
   // Decode using casted types
-  this->encoder->decode(_to_plaintext(ptxt), data);
+  this->bEncoder->decode(_to_plaintext(ptxt), data);
+}
+
+void Aseal::encode_double(vector<double> &data, APlaintext &ptxt)
+{
+  // Gather current context, resolves object
+  auto &seal_context = *(this->get_context());
+
+  // Initialize Encoder object
+  // this->cEncoder = make_shared<CKKSEncoder>(seal_context);
+
+  // Encode using casted types
+  this->cEncoder->encode(data, this->cEncoderScale, _to_plaintext(ptxt));
+}
+
+void Aseal::decode_double(APlaintext &ptxt, vector<double> &data)
+{
+  // Gather current context, resolves object
+  auto &seal_context = *(this->get_context());
+
+  // Initialize Encoder object
+  // this->cEncoder = make_shared<CKKSEncoder>(seal_context);
+
+  // Decode using casted types
+  this->cEncoder->decode(_to_plaintext(ptxt), data);
 }
 
 void Aseal::add(ACiphertext &ctxt, APlaintext &ptxt, ACiphertext &ctxt_res)

--- a/src/backend/aseal.cpp
+++ b/src/backend/aseal.cpp
@@ -101,15 +101,6 @@ string Aseal::ContextGen(scheme scheme,
   }
 }
 
-shared_ptr<SEALContext> inline Aseal::get_context()
-{
-  if (this->context == nullptr)
-  {
-    throw logic_error("Context is not initialized");
-  }
-  return (this->context);
-}
-
 void Aseal::KeyGen()
 {
   // Gather current context, resolves object
@@ -157,6 +148,30 @@ void Aseal::relinearize(ACiphertext &ctxt)
 
   // Relinearize using casted types
   this->evaluator->relinearize_inplace(_to_ciphertext(ctxt), *this->relinKeys);
+}
+
+void Aseal::mod_switch_to(APlaintext &ptxt, ACiphertext &ctxt)
+{
+  // Gather current context, resolves object
+  auto &seal_context = *(this->get_context());
+
+  // Initialize Evaluator object
+  this->evaluator = make_shared<Evaluator>(seal_context);
+
+  // Mod Switch using from Ciphertext parms_id
+  this->evaluator->mod_switch_to_inplace(_to_plaintext(ptxt), _to_ciphertext(ctxt).parms_id());
+}
+
+void Aseal::mod_switch_to(ACiphertext &to, ACiphertext &from)
+{
+  // Gather current context, resolves object
+  auto &seal_context = *(this->get_context());
+
+  // Initialize Evaluator object
+  this->evaluator = make_shared<Evaluator>(seal_context);
+
+  // Mod Switch using from Ciphertext parms_id
+  this->evaluator->mod_switch_to_inplace(_to_ciphertext(to),  _to_ciphertext(from).parms_id());
 }
 
 void Aseal::mod_switch_to_next(ACiphertext &ctxt)

--- a/src/backend/aseal.cpp
+++ b/src/backend/aseal.cpp
@@ -21,7 +21,7 @@ string Aseal::ContextGen(scheme scheme,
                          uint64_t plain_modulus_bit_size,
                          uint64_t plain_modulus,
                          int sec_level,
-                         vector<int> qi_sizes)
+                         vector<int> bit_sizes)
 { try {
   // Initialize parameters with scheme
   EncryptionParameters param(scheme_map_to_seal.at(scheme));
@@ -56,13 +56,13 @@ string Aseal::ContextGen(scheme scheme,
     // Set polynomial modulus degree
     param.set_poly_modulus_degree(poly_modulus_degree);
 
-    if (qi_sizes.size() == 0)
+    if (bit_sizes.size() == 0)
     {
-      throw invalid_argument("CKKS requires at least one qi_size");
+      throw invalid_argument("CKKS requires at least one entry in bit_sizes");
     }
 
     // Set coefficient modulus
-    param.set_coeff_modulus(CoeffModulus::Create(poly_modulus_degree, qi_sizes));
+    param.set_coeff_modulus(CoeffModulus::Create(poly_modulus_degree, bit_sizes));
 
     // Set CKKS Encoder scale
     this->cEncoderScale = pow(2.0, plain_modulus_bit_size);

--- a/src/backend/aseal.cpp
+++ b/src/backend/aseal.cpp
@@ -61,6 +61,11 @@ string Aseal::ContextGen(scheme scheme,
       throw invalid_argument("CKKS requires at least one entry in bit_sizes");
     }
 
+    if (plain_modulus_bit_size < 1)
+    {
+      throw invalid_argument("CKKS requires a positive value for plain_modulus_bit_size");
+    }
+
     // Set coefficient modulus
     param.set_coeff_modulus(CoeffModulus::Create(poly_modulus_degree, bit_sizes));
 

--- a/src/backend/aseal.cpp
+++ b/src/backend/aseal.cpp
@@ -253,8 +253,14 @@ void Aseal::encode_double(vector<double> &data, APlaintext &ptxt)
   // Gather current context, resolves object
   auto &seal_context = *(this->get_context());
 
-  // Initialize Encoder object
-  // this->cEncoder = make_shared<CKKSEncoder>(seal_context);
+  // Encode using casted types
+  this->cEncoder->encode(data, this->cEncoderScale, _to_plaintext(ptxt));
+}
+
+void Aseal::encode_double(double data, APlaintext &ptxt)
+{
+  // Gather current context, resolves object
+  auto &seal_context = *(this->get_context());
 
   // Encode using casted types
   this->cEncoder->encode(data, this->cEncoderScale, _to_plaintext(ptxt));

--- a/src/fhe.cpp
+++ b/src/fhe.cpp
@@ -264,6 +264,16 @@ APlaintext* encode_double(Afhe* afhe, double* data, int size) {
     return ptxt;
 }
 
+APlaintext* encode_double_value(Afhe* afhe, double data) {
+    backend_t lib = backend_map_backend_t[afhe->backend_lib];
+    APlaintext* ptxt = init_plaintext(lib);
+    try {
+        afhe->encode_double(data, *ptxt);
+    }
+    catch (exception &e) { set_error(e); }
+    return ptxt;
+}
+
 double* decode_double(Afhe* afhe, APlaintext* ptxt) {
     backend_t lib = backend_map_backend_t[afhe->backend_lib];
     vector<double> data;

--- a/src/fhe.cpp
+++ b/src/fhe.cpp
@@ -41,7 +41,7 @@ scheme_t scheme_t_from_string(const char* scheme)
     return scheme_t::no_s;
 }
 
-const char* generate_context(Afhe* afhe, scheme_t scheme_type, int poly_mod_degree, int pt_mod_bit, int pt_mod, int sec_level, const int* qi_sizes, int qi_sizes_length)
+const char* generate_context(Afhe* afhe, scheme_t scheme_type, uint64_t poly_mod_degree, uint64_t pt_mod_bit, uint64_t pt_mod, uint64_t sec_level, const uint64_t* qi_sizes, uint64_t qi_sizes_length)
 {
     try {
         scheme a_scheme = scheme_t_map_scheme.at(scheme_type);

--- a/src/fhe.cpp
+++ b/src/fhe.cpp
@@ -41,11 +41,12 @@ scheme_t scheme_t_from_string(const char* scheme)
     return scheme_t::no_s;
 }
 
-const char* generate_context(Afhe* afhe, scheme_t scheme_type, long poly_mod_degree, long pt_mod_bit, long pt_mod, long sec_level)
+const char* generate_context(Afhe* afhe, scheme_t scheme_type, int poly_mod_degree, int pt_mod_bit, int pt_mod, int sec_level, const int* qi_sizes, int qi_sizes_length)
 {
     try {
-        scheme a_scheme = scheme_t_map_scheme[scheme_type];
-        string ctx = afhe->ContextGen(a_scheme, poly_mod_degree, pt_mod_bit, pt_mod, sec_level);
+        scheme a_scheme = scheme_t_map_scheme.at(scheme_type);
+        vector<int> qi_sizes_vec(qi_sizes, qi_sizes + qi_sizes_length);
+        string ctx = afhe->ContextGen(a_scheme, poly_mod_degree, pt_mod_bit, pt_mod, sec_level, qi_sizes_vec);
         // !Important: Must copy string to char* to avoid memory leak
         char *cpy = new char[ctx.size()+1] ;
         strcpy(cpy, ctx.c_str());
@@ -247,6 +248,31 @@ uint64_t* decode_int(Afhe* afhe, APlaintext* ptxt) {
     catch (exception &e) { set_error(e); }
     // Extract vector contents to array
     uint64_t* result = new uint64_t[data.size()];
+    copy(data.begin(), data.end(), result);
+    return result;
+}
+
+APlaintext* encode_double(Afhe* afhe, double* data, int size) {
+    backend_t lib = backend_map_backend_t[afhe->backend_lib];
+    APlaintext* ptxt = init_plaintext(lib);
+    try {
+        // Convert array to vector
+        vector<double> data_vec(data, data + size);
+        afhe->encode_double(data_vec, *ptxt);
+    }
+    catch (exception &e) { set_error(e); }
+    return ptxt;
+}
+
+double* decode_double(Afhe* afhe, APlaintext* ptxt) {
+    backend_t lib = backend_map_backend_t[afhe->backend_lib];
+    vector<double> data;
+    try {
+        afhe->decode_double(*ptxt, data);
+    }
+    catch (exception &e) { set_error(e); }
+    // Extract vector contents to array
+    double* result = new double[data.size()];
     copy(data.begin(), data.end(), result);
     return result;
 }

--- a/test/seal/addition.cpp
+++ b/test/seal/addition.cpp
@@ -154,7 +154,7 @@ TEST(Add, VectorDouble) {
 
   Aseal* fhe = new Aseal();
 
-  string ctx = fhe->ContextGen(scheme::ckks, 8192, 40, -1, -1, {60, 40, 40, 60});
+  string ctx = fhe->ContextGen(scheme::ckks, 8192, pow(2.0, 40), -1, -1, {60, 40, 40, 60});
 
   // Expect two strings not to be equal.
   EXPECT_STREQ(ctx.c_str(), "success: valid");

--- a/test/seal/addition.cpp
+++ b/test/seal/addition.cpp
@@ -150,6 +150,25 @@ TEST(Add, VectorInteger) {
   }
 }
 
+TEST(Add, Double) {
+  Aseal* fhe = new Aseal();
+  string ctx = fhe->ContextGen(scheme::ckks, 8192, 40, -1, -1, {60, 40, 40, 60});
+  // Expect two strings not to be equal.
+  EXPECT_STREQ(ctx.c_str(), "success: valid");
+
+  fhe->KeyGen();
+  /*
+  We create plaintexts for PI, 0.4, and 1 using an overload of CKKSEncoder::encode
+  that encodes the given floating-point value to every slot in the vector.
+  */
+  AsealPlaintext plain_coeff3, plain_coeff1, plain_coeff0;
+  fhe->encode_double(3.14159265, plain_coeff3);
+  fhe->encode_double(0.4, plain_coeff1);
+  fhe->encode_double(1.0, plain_coeff0);
+
+  // TODO: Add plaintext (encoded) doubles to vector ciphertexts.
+}
+
 TEST(Add, VectorDouble) {
 
   Aseal* fhe = new Aseal();

--- a/test/seal/addition.cpp
+++ b/test/seal/addition.cpp
@@ -150,25 +150,6 @@ TEST(Add, VectorInteger) {
   }
 }
 
-TEST(Add, Double) {
-  Aseal* fhe = new Aseal();
-  string ctx = fhe->ContextGen(scheme::ckks, 8192, 40, -1, -1, {60, 40, 40, 60});
-  // Expect two strings not to be equal.
-  EXPECT_STREQ(ctx.c_str(), "success: valid");
-
-  fhe->KeyGen();
-  /*
-  We create plaintexts for PI, 0.4, and 1 using an overload of CKKSEncoder::encode
-  that encodes the given floating-point value to every slot in the vector.
-  */
-  AsealPlaintext plain_coeff3, plain_coeff1, plain_coeff0;
-  fhe->encode_double(3.14159265, plain_coeff3);
-  fhe->encode_double(0.4, plain_coeff1);
-  fhe->encode_double(1.0, plain_coeff0);
-
-  // TODO: Add plaintext (encoded) doubles to vector ciphertexts.
-}
-
 TEST(Add, VectorDouble) {
 
   Aseal* fhe = new Aseal();

--- a/test/seal/addition.cpp
+++ b/test/seal/addition.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h> // NOLINT
 #include <aseal.h>       /* Microsoft SEAL */
 #include <map>
+#include <cstdint>
 
 TEST(Add, IntegersToHexadecimal) {
   std::map<int, int> plaintextToModulus = {
@@ -146,5 +147,100 @@ TEST(Add, VectorInteger) {
         EXPECT_EQ(expect[i], decode_res_cipher[i]);
       }
     }
+  }
+}
+
+TEST(Add, VectorDouble) {
+
+  Aseal* fhe = new Aseal();
+
+  string ctx = fhe->ContextGen(scheme::ckks, 8192, 40, -1, -1, {60, 40, 40, 60});
+
+  // Expect two strings not to be equal.
+  EXPECT_STREQ(ctx.c_str(), "success: valid");
+
+  fhe->KeyGen();
+  fhe->RelinKeyGen();
+
+  size_t slot_count = fhe->slot_count();
+
+  /**
+   * Create an input vector with floating point values 0 ... 1.
+  */
+  vector<double> x;
+  x.reserve(slot_count);
+  double curr_point = 0;
+  double step_size = 1.0 / (static_cast<double>(slot_count) - 1);
+  for (size_t i = 0; i < slot_count; i++)
+  {
+      x.push_back(curr_point);
+      curr_point += step_size;
+  }
+  // cout << "X vector: " << endl;
+  // for (size_t i = 0; i < slot_count; i++)
+  // {
+  //     cout << x[i] << " ";
+  // }
+
+  AsealPlaintext pt_x = AsealPlaintext();
+
+  fhe->encode_double(x, pt_x);
+
+  AsealCiphertext ct_x = AsealCiphertext();
+
+  fhe->encrypt(pt_x, ct_x);
+
+  /**
+   * Create an addend vector with floating point values 0 ... 1.
+  */
+  vector<double> add;
+  add.reserve(slot_count);
+  curr_point = 0;
+  step_size = 1.0 / (static_cast<double>(slot_count) - 1);
+  for (size_t i = 0; i < slot_count; i++)
+  {
+      add.push_back(curr_point);
+      curr_point += step_size;
+  }
+  // cout << "Add vector: " << endl;
+  // for (size_t i = 0; i < slot_count; i++)
+  // {
+  //     cout << add[i] << " ";
+  // }
+  AsealPlaintext pt_add = AsealPlaintext();
+  fhe->encode_double(add, pt_add);
+  AsealCiphertext ct_add = AsealCiphertext();
+  fhe->encrypt(pt_add, ct_add);
+
+  AsealCiphertext ct_res = AsealCiphertext();
+
+  fhe->add(ct_x, ct_add, ct_res);
+  fhe->relinearize(ct_res);
+
+  AsealPlaintext decrypt_res = AsealPlaintext();
+  fhe->decrypt(ct_res, decrypt_res);
+
+  vector<double> decode_res;
+  fhe->decode_double(decrypt_res, decode_res);
+
+  for (int i = 0; i < x.size(); i++) {
+    double expect = x[i] + add[i];
+    // Compare up to 7 decimal places.
+    EXPECT_NEAR(expect, decode_res[i], 0.0000001);
+  }
+
+  // Without relinearization
+  AsealCiphertext ct_res_no_relin = AsealCiphertext();
+  fhe->add(ct_x, pt_add, ct_res_no_relin);
+
+  AsealPlaintext decrypt_res_no_relin = AsealPlaintext();
+  fhe->decrypt(ct_res_no_relin, decrypt_res_no_relin);
+  vector<double> decode_res_no_relin;
+  fhe->decode_double(decrypt_res_no_relin, decode_res_no_relin);
+
+  for (int i = 0; i < x.size(); i++) {
+    double expect = x[i] + add[i];
+    // Compare up to 7 decimal places.
+    EXPECT_NEAR(expect, decode_res_no_relin[i], 0.0000001);
   }
 }

--- a/test/seal/ckks_basics.cpp
+++ b/test/seal/ckks_basics.cpp
@@ -1,0 +1,281 @@
+#include <gtest/gtest.h> // NOLINT
+#include <aseal.h>       /* Microsoft SEAL */
+#include <map>
+
+using namespace std;
+using namespace seal;
+
+TEST(CKKS, Basics)
+{
+    /*
+    In this example we demonstrate evaluating a polynomial function
+
+        PI*x^3 + 0.4*x + 1
+
+    on encrypted floating-point input data x for a set of 4096 equidistant points
+    in the interval [0, 1]. This example demonstrates many of the main features
+    of the CKKS scheme, but also the challenges in using it.
+    */
+    Aseal* fhe = new Aseal();
+
+    /*
+    We saw in `2_encoders.cpp' that multiplication in CKKS causes scales
+    in ciphertexts to grow. The scale of any ciphertext must not get too close
+    to the total size of coeff_modulus, or else the ciphertext simply runs out of
+    room to store the scaled-up plaintext. The CKKS scheme provides a `rescale'
+    functionality that can reduce the scale, and stabilize the scale expansion.
+
+    Rescaling is a kind of modulus switch operation (recall `3_levels.cpp').
+    As modulus switching, it removes the last of the primes from coeff_modulus,
+    but as a side-effect it scales down the ciphertext by the removed prime.
+    Usually we want to have perfect control over how the scales are changed,
+    which is why for the CKKS scheme it is more common to use carefully selected
+    primes for the coeff_modulus.
+
+    More precisely, suppose that the scale in a CKKS ciphertext is S, and the
+    last prime in the current coeff_modulus (for the ciphertext) is P. Rescaling
+    to the next level changes the scale to S/P, and removes the prime P from the
+    coeff_modulus, as usual in modulus switching. The number of primes limits
+    how many rescalings can be done, and thus limits the multiplicative depth of
+    the computation.
+
+    It is possible to choose the initial scale freely. One good strategy can be
+    to is to set the initial scale S and primes P_i in the coeff_modulus to be
+    very close to each other. If ciphertexts have scale S before multiplication,
+    they have scale S^2 after multiplication, and S^2/P_i after rescaling. If all
+    P_i are close to S, then S^2/P_i is close to S again. This way we stabilize the
+    scales to be close to S throughout the computation. Generally, for a circuit
+    of depth D, we need to rescale D times, i.e., we need to be able to remove D
+    primes from the coefficient modulus. Once we have only one prime left in the
+    coeff_modulus, the remaining prime must be larger than S by a few bits to
+    preserve the pre-decimal-point value of the plaintext.
+
+    Therefore, a generally good strategy is to choose parameters for the CKKS
+    scheme as follows:
+
+        (1) Choose a 60-bit prime as the first prime in coeff_modulus. This will
+            give the highest precision when decrypting;
+        (2) Choose another 60-bit prime as the last element of coeff_modulus, as
+            this will be used as the special prime and should be as large as the
+            largest of the other primes;
+        (3) Choose the intermediate primes to be close to each other.
+
+    We use CoeffModulus::Create to generate primes of the appropriate size. Note
+    that our coeff_modulus is 200 bits total, which is below the bound for our
+    poly_modulus_degree: CoeffModulus::MaxBitCount(8192) returns 218.
+
+    We choose the initial scale to be 2^40. At the last level, this leaves us
+    60-40=20 bits of precision before the decimal point, and enough (roughly
+    10-20 bits) of precision after the decimal point. Since our intermediate
+    primes are 40 bits (in fact, they are very close to 2^40), we can achieve
+    scale stabilization as described above.
+    */
+    vector<int> primes = { 60, 40, 40, 60 };
+    double scale = pow(2.0, 40); // 2^40
+    size_t poly_modulus_degree = 8192;
+    string ctx = fhe->ContextGen(scheme::ckks, poly_modulus_degree, scale, -1, -1, primes);
+    EXPECT_STREQ(ctx.c_str(), "success: valid");
+
+    fhe->KeyGen();
+    fhe->RelinKeyGen();
+
+    size_t slot_count = fhe->slot_count();
+    cout << "Number of slots: " << slot_count << endl;
+
+    vector<double> input;
+    input.reserve(slot_count);
+    double curr_point = 0;
+    double step_size = 1.0 / (static_cast<double>(slot_count) - 1);
+    for (size_t i = 0; i < slot_count; i++)
+    {
+        input.push_back(curr_point);
+        curr_point += step_size;
+    }
+    cout << "Evaluating polynomial PI*x^3 + 0.4x + 1 ..." << endl;
+
+    /*
+    We create plaintexts for PI, 0.4, and 1 using an overload of CKKSEncoder::encode
+    that encodes the given floating-point value to every slot in the vector.
+    */
+    AsealPlaintext plain_coeff3, plain_coeff1, plain_coeff0;
+    fhe->encode_double(3.14159265, plain_coeff3);
+    fhe->encode_double(0.4, plain_coeff1);
+    fhe->encode_double(1.0, plain_coeff0);
+
+    AsealPlaintext x_plain;
+    cout << "Encode input vectors." << endl;
+    fhe->encode_double(input, x_plain);
+    AsealCiphertext x1_encrypted;
+    fhe->encrypt(x_plain, x1_encrypted);
+
+    /*
+    To compute x^3 we first compute x^2 and relinearize. However, the scale has
+    now grown to 2^80.
+    */
+    AsealCiphertext x2_encrypted;
+    cout << "Compute x^2 and relinearize:" << endl;
+    fhe->multiply(x1_encrypted, x1_encrypted, x2_encrypted);
+    fhe->relinearize(x2_encrypted);
+    cout << "    + Scale of x^2 before rescale: " << log2(x2_encrypted.scale()) << " bits" << endl;
+
+    /*
+    Now rescale; in addition to a modulus switch, the scale is reduced down by
+    a factor equal to the prime that was switched away (40-bit prime). Hence, the
+    new scale should be close to 2^40. Note, however, that the scale is not equal
+    to 2^40: this is because the 40-bit prime is only close to 2^40.
+    */
+    cout << "Rescale x^2." << endl;
+    fhe->rescale_to_next(x2_encrypted);
+    cout << "    + Scale of x^2 after rescale: " << log2(x2_encrypted.scale()) << " bits" << endl;
+
+    /*
+    Now x2_encrypted is at a different level than x1_encrypted, which prevents us
+    from multiplying them to compute x^3. We could simply switch x1_encrypted to
+    the next parameters in the modulus switching chain. However, since we still
+    need to multiply the x^3 term with PI (plain_coeff3), we instead compute PI*x
+    first and multiply that with x^2 to obtain PI*x^3. To this end, we compute
+    PI*x and rescale it back from scale 2^80 to something close to 2^40.
+    */
+    cout << "Compute and rescale PI*x." << endl;
+    AsealCiphertext x1_encrypted_coeff3;
+    fhe->multiply(x1_encrypted, plain_coeff3, x1_encrypted_coeff3);
+    cout << "    + Scale of PI*x before rescale: " << log2(x1_encrypted_coeff3.scale()) << " bits" << endl;
+    fhe->rescale_to_next(x1_encrypted_coeff3);
+    cout << "    + Scale of PI*x after rescale: " << log2(x1_encrypted_coeff3.scale()) << " bits" << endl;
+
+    /*
+    Since x2_encrypted and x1_encrypted_coeff3 have the same exact scale and use
+    the same encryption parameters, we can multiply them together. We write the
+    result to pi_x3_encrypted, relinearize, and rescale. Note that again the scale
+    is something close to 2^40, but not exactly 2^40 due to yet another scaling
+    by a prime. We are down to the last level in the modulus switching chain.
+    */
+    cout << "Compute, relinearize, and rescale (PI*x)*x^2." << endl;
+    AsealCiphertext pi_x3_encrypted;
+    fhe->multiply(x2_encrypted, x1_encrypted_coeff3, pi_x3_encrypted);
+    fhe->relinearize(pi_x3_encrypted);
+    cout << "    + Scale of PI*x^3 before rescale: " << log2(pi_x3_encrypted.scale()) << " bits" << endl;
+    fhe->rescale_to_next(pi_x3_encrypted);
+    cout << "    + Scale of PI*x^3 after rescale: " << log2(pi_x3_encrypted.scale()) << " bits" << endl;
+
+    /*
+    Next we compute the degree one term. All this requires is one multiply_plain
+    with plain_coeff1. We overwrite x1_encrypted with the result.
+    */
+    cout << "Compute and rescale 0.4*x." << endl;
+    AsealCiphertext x1_encrypted_coeff1;
+    fhe->multiply(x1_encrypted, plain_coeff1, x1_encrypted_coeff1);
+    cout << "    + Scale of 0.4*x before rescale: " << log2(x1_encrypted_coeff1.scale()) << " bits" << endl;
+    fhe->rescale_to_next(x1_encrypted_coeff1);
+    cout << "    + Scale of 0.4*x after rescale: " << log2(x1_encrypted_coeff1.scale()) << " bits" << endl;
+
+    /*
+    Now we would hope to compute the sum of all three terms. However, there is
+    a serious problem: the encryption parameters used by all three terms are
+    different due to modulus switching from rescaling.
+
+    Encrypted addition and subtraction require that the scales of the inputs are
+    the same, and also that the encryption parameters (parms_id) match. If there
+    is a mismatch, Evaluator will throw an exception.
+    */
+    // cout << "Parameters used by all three terms are different." << endl;
+    // cout << "    + Modulus chain index for x3_encrypted: "
+    //      << context.get_context_data(x3_encrypted.parms_id())->chain_index() << endl;
+    // cout << "    + Modulus chain index for x1_encrypted: "
+    //      << context.get_context_data(x1_encrypted.parms_id())->chain_index() << endl;
+    // cout << "    + Modulus chain index for plain_coeff0: "
+    //      << context.get_context_data(plain_coeff0.parms_id())->chain_index() << endl;
+    // cout << endl;
+
+    /*
+    Let us carefully consider what the scales are at this point. We denote the
+    primes in coeff_modulus as P_0, P_1, P_2, P_3, in this order. P_3 is used as
+    the special modulus and is not involved in rescalings. After the computations
+    above the scales in ciphertexts are:
+
+        - Product x^2 has scale 2^80 and is at level 2;
+        - Product PI*x has scale 2^80 and is at level 2;
+        - We rescaled both down to scale 2^80/P_2 and level 1;
+        - Product PI*x^3 has scale (2^80/P_2)^2;
+        - We rescaled it down to scale (2^80/P_2)^2/P_1 and level 0;
+        - Product 0.4*x has scale 2^80;
+        - We rescaled it down to scale 2^80/P_2 and level 1;
+        - The contant term 1 has scale 2^40 and is at level 2.
+
+    Although the scales of all three terms are approximately 2^40, their exact
+    values are different, hence they cannot be added together.
+    */
+    cout << "The exact scales of all three terms are different:" << endl;
+    ios old_fmt(nullptr);
+    old_fmt.copyfmt(cout);
+    cout << fixed << setprecision(10);
+    cout << "    + Exact scale in PI*x^3: " << pi_x3_encrypted.scale() << endl;
+    cout << "    + Exact scale in  0.4*x: " << x1_encrypted_coeff1.scale() << endl;
+    cout << "    + Exact scale in      1: " << plain_coeff0.scale() << endl;
+    cout << endl;
+    cout.copyfmt(old_fmt);
+
+    /*
+    There are many ways to fix this problem. Since P_2 and P_1 are really close
+    to 2^40, we can simply "lie" to Microsoft SEAL and set the scales to be the
+    same. For example, changing the scale of PI*x^3 to 2^40 simply means that we
+    scale the value of PI*x^3 by 2^120/(P_2^2*P_1), which is very close to 1.
+    This should not result in any noticeable error.
+
+    Another option would be to encode 1 with scale 2^80/P_2, do a multiply_plain
+    with 0.4*x, and finally rescale. In this case we would need to additionally
+    make sure to encode 1 with appropriate encryption parameters (parms_id).
+
+    In this example we will use the first (simplest) approach and simply change
+    the scale of PI*x^3 and 0.4*x to 2^40.
+    */
+    cout << "Normalize scales to 2^40." << endl;
+    pi_x3_encrypted.set_scale(pow(2.0, 40));
+    x1_encrypted_coeff1.set_scale(pow(2.0, 40));
+
+    /*
+    We still have a problem with mismatching encryption parameters. This is easy
+    to fix by using traditional modulus switching (no rescaling). CKKS supports
+    modulus switching just like the BFV scheme, allowing us to switch away parts
+    of the coefficient modulus when it is simply not needed.
+    */
+    cout << "Normalize encryption parameters to the lowest level." << endl;
+    fhe->mod_switch_to_next(x1_encrypted_coeff1); // TODO: mod_switch_to_level(x1_encrypted_coeff1, pi_x3_encrypted.parms_id())
+    fhe->mod_switch_to_next(plain_coeff0);
+
+    /*
+    All three ciphertexts are now compatible and can be added.
+    */
+    AsealCiphertext add_ct;
+    AsealCiphertext add_one;
+    fhe->add(pi_x3_encrypted, x1_encrypted_coeff1, add_ct);
+    fhe->add(add_ct, plain_coeff0, add_one);
+
+    /*
+    First print the true result.
+    */
+    AsealPlaintext plain_result;
+    cout << "Decrypt and decode PI*x^3 + 0.4x + 1." << endl;
+    vector<double> true_result;
+    for (size_t i = 0; i < input.size(); i++)
+    {
+        double x = input[i];
+        true_result.push_back((3.14159265 * x * x + 0.4) * x + 1);
+    }
+
+    /*
+    Decrypt, decode, and print the result.
+    */
+    fhe->decrypt(add_one, plain_result);
+    vector<double> result;
+    fhe->decode_double(plain_result, result);
+    for (int i = 0; i < true_result.size(); i++) {
+      // Compare up to 7 decimal places.
+      EXPECT_NEAR(true_result[i], result[i], 0.0000001);
+    }
+    /*
+    While we did not show any computations on complex numbers in these examples,
+    the CKKSEncoder would allow us to have done that just as easily. Additions
+    and multiplications of complex numbers behave just as one would expect.
+    */
+}

--- a/test/seal/multiplication.cpp
+++ b/test/seal/multiplication.cpp
@@ -170,7 +170,7 @@ TEST(Multiply, VectorDouble) {
 
   Aseal* fhe = new Aseal();
 
-  string ctx = fhe->ContextGen(scheme::ckks, 8192, 40, -1, -1, {60, 40, 40, 60});
+  string ctx = fhe->ContextGen(scheme::ckks, 8192, pow(2.0, 40), -1, -1, {60, 40, 40, 60});
 
   // Expect two strings not to be equal.
   EXPECT_STREQ(ctx.c_str(), "success: valid");
@@ -264,7 +264,7 @@ TEST(Multiply, VectorDouble) {
 TEST(Multiply, PiXSquared) {
   // π * x^2
   Aseal* fhe = new Aseal();
-  string ctx = fhe->ContextGen(scheme::ckks, 8192, 40, -1, -1, {60, 40, 40, 60});
+  string ctx = fhe->ContextGen(scheme::ckks, 8192, pow(2.0, 40), -1, -1, {60, 40, 40, 60});
   // Expect two strings not to be equal.
   EXPECT_STREQ(ctx.c_str(), "success: valid");
 

--- a/test/seal/multiplication.cpp
+++ b/test/seal/multiplication.cpp
@@ -165,3 +165,98 @@ TEST(Multiply, VectorInteger) {
     }
   }
 }
+
+TEST(Multiply, VectorDouble) {
+
+  Aseal* fhe = new Aseal();
+
+  string ctx = fhe->ContextGen(scheme::ckks, 8192, 40, -1, -1, {60, 40, 40, 60});
+
+  // Expect two strings not to be equal.
+  EXPECT_STREQ(ctx.c_str(), "success: valid");
+
+  fhe->KeyGen();
+  fhe->RelinKeyGen();
+
+  size_t slot_count = fhe->slot_count();
+
+  /**
+   * Create an input vector with floating point values 0 ... 1.
+  */
+  vector<double> x;
+  x.reserve(slot_count);
+  double curr_point = 0;
+  double step_size = 1.0 / (static_cast<double>(slot_count) - 1);
+  for (size_t i = 0; i < slot_count; i++)
+  {
+      x.push_back(curr_point);
+      curr_point += step_size;
+  }
+  // cout << "X vector: " << endl;
+  // for (size_t i = 0; i < slot_count; i++)
+  // {
+  //     cout << x[i] << " ";
+  // }
+
+  AsealPlaintext pt_x = AsealPlaintext();
+
+  fhe->encode_double(x, pt_x);
+
+  AsealCiphertext ct_x = AsealCiphertext();
+
+  fhe->encrypt(pt_x, ct_x);
+
+  /**
+   * Create an addend vector with floating point values 0 ... 1.
+  */
+  vector<double> m;
+  m.reserve(slot_count);
+  curr_point = 0;
+  step_size = 1.0 / (static_cast<double>(slot_count) - 1);
+  for (size_t i = 0; i < slot_count; i++)
+  {
+      m.push_back(curr_point);
+      curr_point += step_size;
+  }
+  // cout << "Add vector: " << endl;
+  // for (size_t i = 0; i < slot_count; i++)
+  // {
+  //     cout << add[i] << " ";
+  // }
+  AsealPlaintext pt_m = AsealPlaintext();
+  fhe->encode_double(m, pt_m);
+  AsealCiphertext ct_m = AsealCiphertext();
+  fhe->encrypt(pt_m, ct_m);
+
+  AsealCiphertext ct_res = AsealCiphertext();
+
+  fhe->multiply(ct_x, ct_m, ct_res);
+  fhe->relinearize(ct_res);
+
+  AsealPlaintext decrypt_res = AsealPlaintext();
+  fhe->decrypt(ct_res, decrypt_res);
+
+  vector<double> decode_res;
+  fhe->decode_double(decrypt_res, decode_res);
+
+  for (int i = 0; i < x.size(); i++) {
+    double expect = x[i] * m[i];
+    // Compare up to 7 decimal places.
+    EXPECT_NEAR(expect, decode_res[i], 0.0000001);
+  }
+
+  // Without relinearization
+  AsealCiphertext ct_res_no_relin = AsealCiphertext();
+  fhe->multiply(ct_x, pt_m, ct_res_no_relin);
+
+  AsealPlaintext decrypt_res_no_relin = AsealPlaintext();
+  fhe->decrypt(ct_res_no_relin, decrypt_res_no_relin);
+  vector<double> decode_res_no_relin;
+  fhe->decode_double(decrypt_res_no_relin, decode_res_no_relin);
+
+  for (int i = 0; i < x.size(); i++) {
+    double expect = x[i] * m[i];
+    // Compare up to 7 decimal places.
+    EXPECT_NEAR(expect, decode_res_no_relin[i], 0.0000001);
+  }
+}

--- a/test/seal/subtraction.cpp
+++ b/test/seal/subtraction.cpp
@@ -92,7 +92,7 @@ TEST(Subtract, VectorInteger) {
       /*
         Here we create the following arrays:
             x = [ 1,  2,  3,  4,  0,  0,  0,  0 ]
-          add = [ 2,  4,  6,  8,  0,  0,  0,  0 ]
+          sub = [ 2,  4,  6,  8,  0,  0,  0,  0 ]
       */
       vector<uint64_t> x(8, 0ULL);
       x[0] = 2ULL;
@@ -147,5 +147,100 @@ TEST(Subtract, VectorInteger) {
         EXPECT_EQ(expect[i], decode_res_cipher[i]);
       }
     }
+  }
+}
+
+TEST(Subtract, VectorDouble) {
+
+  Aseal* fhe = new Aseal();
+
+  string ctx = fhe->ContextGen(scheme::ckks, 8192, 40, -1, -1, {60, 40, 40, 60});
+
+  // Expect two strings not to be equal.
+  EXPECT_STREQ(ctx.c_str(), "success: valid");
+
+  fhe->KeyGen();
+  fhe->RelinKeyGen();
+
+  size_t slot_count = fhe->slot_count();
+
+  /**
+   * Create an input vector with floating point values 0 ... 1.
+  */
+  vector<double> x;
+  x.reserve(slot_count);
+  double curr_point = 0;
+  double step_size = 1.0 / (static_cast<double>(slot_count) - 1);
+  for (size_t i = 0; i < slot_count; i++)
+  {
+      x.push_back(curr_point);
+      curr_point += step_size;
+  }
+  // cout << "X vector: " << endl;
+  // for (size_t i = 0; i < slot_count; i++)
+  // {
+  //     cout << x[i] << " ";
+  // }
+
+  AsealPlaintext pt_x = AsealPlaintext();
+
+  fhe->encode_double(x, pt_x);
+
+  AsealCiphertext ct_x = AsealCiphertext();
+
+  fhe->encrypt(pt_x, ct_x);
+
+  /**
+   * Create an subend vector with floating point values 0 ... 1.
+  */
+  vector<double> sub;
+  sub.reserve(slot_count);
+  curr_point = 0;
+  step_size = 1.0 / (static_cast<double>(slot_count) - 1);
+  for (size_t i = 0; i < slot_count; i++)
+  {
+      sub.push_back(curr_point);
+      curr_point += step_size;
+  }
+  // cout << "Subtract vector: " << endl;
+  // for (size_t i = 0; i < slot_count; i++)
+  // {
+  //     cout << sub[i] << " ";
+  // }
+  AsealPlaintext pt_sub = AsealPlaintext();
+  fhe->encode_double(sub, pt_sub);
+  AsealCiphertext ct_sub = AsealCiphertext();
+  fhe->encrypt(pt_sub, ct_sub);
+
+  AsealCiphertext ct_res = AsealCiphertext();
+
+  fhe->subtract(ct_x, ct_sub, ct_res);
+  fhe->relinearize(ct_res);
+
+  AsealPlaintext decrypt_res = AsealPlaintext();
+  fhe->decrypt(ct_res, decrypt_res);
+
+  vector<double> decode_res;
+  fhe->decode_double(decrypt_res, decode_res);
+
+  for (int i = 0; i < x.size(); i++) {
+    double expect = x[i] - sub[i];
+    // Compare up to 7 decimal places.
+    EXPECT_NEAR(expect, decode_res[i], 0.0000001);
+  }
+
+  // Without relinearization
+  AsealCiphertext ct_res_no_relin = AsealCiphertext();
+  fhe->subtract(ct_x, pt_sub, ct_res_no_relin);
+
+  AsealPlaintext decrypt_res_no_relin = AsealPlaintext();
+  fhe->decrypt(ct_res_no_relin, decrypt_res_no_relin);
+  vector<double> decode_res_no_relin;
+  fhe->decode_double(decrypt_res_no_relin, decode_res_no_relin);
+
+  for (int i = 0; i < x.size(); i++) {
+    double expect = x[i] - sub[i];
+    // Compare up to 7 decimal places.
+    EXPECT_NEAR(expect, decode_res_no_relin[i], 0.0000001);
   }
 }

--- a/test/seal/subtraction.cpp
+++ b/test/seal/subtraction.cpp
@@ -154,7 +154,7 @@ TEST(Subtract, VectorDouble) {
 
   Aseal* fhe = new Aseal();
 
-  string ctx = fhe->ContextGen(scheme::ckks, 8192, 40, -1, -1, {60, 40, 40, 60});
+  string ctx = fhe->ContextGen(scheme::ckks, 8192, pow(2.0, 40), -1, -1, {60, 40, 40, 60});
 
   // Expect two strings not to be equal.
   EXPECT_STREQ(ctx.c_str(), "success: valid");


### PR DESCRIPTION
https://github.com/microsoft/SEAL/blob/main/native/examples/5_ckks_basics.cpp
Support for CKKS basics, floating point arithmetic.

Exposes: `encode_double_value` / `encode_double` / `decode_double` at interface
Extends: `generate_context` to support `qi_sizes` (prime) and `qi_sizes_length` (size of primes array)

TODO:
- [x] Detailed doc-strings for encode_double vs encode_int
- [x] CPP: Subtraction testing
- [x] Dart: All operation tests
- [x] Support for doubles (not just vector). [example](https://github.com/microsoft/SEAL/blob/main/native/examples/5_ckks_basics.cpp#L124)
- [x] Add CKKS Basics test from SEAL