### PR TITLE
Levels - SEAL Basics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,10 +86,10 @@ if(DEFINED UNIT_TEST AND UNIT_TEST STREQUAL "ON")
     # SEAL Basics
     add_executable(
         seal_basics
-        # test/seal/basics/1_bfv.cpp
+        test/seal/basics/1_bfv.cpp
         test/seal/basics/3_levels.cpp
-        # test/seal/basics/4_bgv.cpp
-        # test/seal/basics/5_ckks.cpp
+        test/seal/basics/4_bgv.cpp
+        test/seal/basics/5_ckks.cpp
     )
     include_directories(test/seal/basics)
     target_link_libraries(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ if(DEFINED UNIT_TEST AND UNIT_TEST STREQUAL "ON")
         test/seal/multiplication.cpp
         test/seal/relinearization.cpp
         test/seal/basics/1_bfv.cpp
+        test/seal/basics/3_levels.cpp
         test/seal/basics/4_bgv.cpp
         test/seal/basics/5_ckks.cpp
     )
@@ -85,9 +86,10 @@ if(DEFINED UNIT_TEST AND UNIT_TEST STREQUAL "ON")
     # SEAL Basics
     add_executable(
         seal_basics
-        test/seal/basics/1_bfv.cpp
-        test/seal/basics/4_bgv.cpp
-        test/seal/basics/5_ckks.cpp
+        # test/seal/basics/1_bfv.cpp
+        test/seal/basics/3_levels.cpp
+        # test/seal/basics/4_bgv.cpp
+        # test/seal/basics/5_ckks.cpp
     )
     include_directories(test/seal/basics)
     target_link_libraries(

--- a/include/afhe.h
+++ b/include/afhe.h
@@ -72,7 +72,7 @@ public:
 class APublicKey {
 public:
   virtual ~APublicKey() = default;
-  virtual ACiphertext& data() = 0;
+  // virtual ACiphertext& data() = 0;
   // virtual TODO param_id() = 0;
 };
 
@@ -82,7 +82,14 @@ public:
 class ASecretKey {
 public:
   virtual ~ASecretKey() = default;
-  virtual APlaintext& data() = 0;
+  // virtual APlaintext& data() = 0;
+  // virtual TODO param_id() = 0;
+};
+
+class ARelinKey {
+public:
+  virtual ~ARelinKey() = default;
+  // virtual ACiphertext& data() = 0;
   // virtual TODO param_id() = 0;
 };
 
@@ -123,6 +130,8 @@ public:
     uint64_t plain_modulus_bit_size, uint64_t plain_modulus,
     int sec_level, vector<int> qi_sizes = {}) = 0;
 
+  virtual void disable_mod_switch() = 0;
+
   // virtual vector<uint64_t> get_qi() = 0;
   // virtual uint64_t get_plain_modulus() = 0;
   // virtual size_t get_poly_modulus_degree() = 0;
@@ -149,6 +158,11 @@ public:
    * @brief Returns the secret key.
   */
   virtual ASecretKey& get_secret_key() = 0;
+
+  /**
+   * @brief Returns the relinearization keys.
+  */
+  virtual ARelinKey& get_relin_keys() = 0;
 
   /**
    * @brief Generates a public and private key pair; derived from the private key.

--- a/include/afhe.h
+++ b/include/afhe.h
@@ -130,6 +130,9 @@ public:
     uint64_t plain_modulus_bit_size, uint64_t plain_modulus,
     int sec_level, vector<int> qi_sizes = {}) = 0;
 
+  /**
+   * @brief Disables the modulus switching chain
+  */
   virtual void disable_mod_switch() = 0;
 
   // virtual vector<uint64_t> get_qi() = 0;

--- a/include/afhe.h
+++ b/include/afhe.h
@@ -45,6 +45,47 @@ enum scheme : int
   bgv = 3,  /* Brakerski-Gentry-Vaikuntanathan */
 };
 
+// ------------------ Abstractions ------------------
+/**
+ * @brief Abstraction for Plaintexts.
+ */
+class APlaintext {
+public:
+  virtual ~APlaintext() = default;
+  virtual string to_string() = 0;
+};
+
+/**
+ * @brief Abstraction for Ciphertexts.
+ */
+class ACiphertext{
+public:
+  virtual ~ACiphertext() = default;
+  virtual size_t size() = 0;
+  virtual double scale() = 0;
+  virtual void set_scale(double scale) = 0;
+};
+
+/**
+ * @brief Abstraction for public keys.
+*/
+class APublicKey {
+public:
+  virtual ~APublicKey() = default;
+  virtual ACiphertext& data() = 0;
+  // virtual TODO param_id() = 0;
+};
+
+/**
+ * @brief Abstraction for secret keys.
+*/
+class ASecretKey {
+public:
+  virtual ~ASecretKey() = default;
+  virtual APlaintext& data() = 0;
+  // virtual TODO param_id() = 0;
+};
+
 /**
  * @class Afhe
  * @brief The Afhe class represents a Fully Homomorphic Encryption (FHE) scheme.
@@ -98,6 +139,16 @@ public:
    * @brief Generates a public and private key pair.
   */
   virtual void KeyGen() = 0;
+
+  /**
+   * @brief Returns the public key.
+  */
+  virtual APublicKey& get_public_key() = 0;
+
+  /**
+   * @brief Returns the secret key.
+  */
+  virtual ASecretKey& get_secret_key() = 0;
 
   /**
    * @brief Generates a public and private key pair; derived from the private key.
@@ -312,26 +363,6 @@ public:
    * This function performs the multiplication operation on a ciphertext and a plaintext and stores the result in a ciphertext.
   */
   virtual void multiply(ACiphertext &ctxt, APlaintext &ptxt, ACiphertext &ctxt_res) = 0;
-};
-
-/**
- * @brief Abstraction for Plaintexts.
- */
-class APlaintext {
-public:
-  virtual ~APlaintext() = default;
-  virtual string to_string() = 0;
-};
-
-/**
- * @brief Abstraction for Ciphertexts.
- */
-class ACiphertext{
-public:
-  virtual ~ACiphertext() = default;
-  virtual size_t size() = 0;
-  virtual double scale() = 0;
-  virtual void set_scale(double scale) = 0;
 };
 
 #endif /* AFHE_H */

--- a/include/backend/aseal.h
+++ b/include/backend/aseal.h
@@ -90,6 +90,7 @@ class AsealPlaintext : public APlaintext, public seal::Plaintext {
 public:
   // Inherit constructors
   using seal::Plaintext::Plaintext;
+  AsealPlaintext(const seal::Plaintext &ptxt) : seal::Plaintext(ptxt) {};
   string to_string() override {
     return seal::Plaintext::to_string();
   }
@@ -99,6 +100,9 @@ public:
 inline AsealPlaintext& _to_plaintext(APlaintext& p){
   return dynamic_cast<AsealPlaintext&>(p);
 };
+inline APlaintext& _from_plaintext(AsealPlaintext& p){
+  return dynamic_cast<APlaintext&>(p);
+};
 
 /**
  * @brief Abstraction for Ciphertext
@@ -106,6 +110,7 @@ inline AsealPlaintext& _to_plaintext(APlaintext& p){
 class AsealCiphertext : public ACiphertext, public seal::Ciphertext {
 public:
   using seal::Ciphertext::Ciphertext;
+  AsealCiphertext(const seal::Ciphertext &ctxt) : seal::Ciphertext(ctxt) {};
   ~AsealCiphertext(){};
   size_t size() override {
     return seal::Ciphertext::size();
@@ -121,6 +126,53 @@ public:
 // DYNAMIC CASTING
 inline AsealCiphertext& _to_ciphertext(ACiphertext& c){
   return dynamic_cast<AsealCiphertext&>(c);
+};
+inline ACiphertext& _from_ciphertext(AsealCiphertext& c){
+  return dynamic_cast<ACiphertext&>(c);
+};
+
+/**
+ * @brief Abstraction for PublicKey
+*/
+class AsealPublicKey : public APublicKey, public seal::PublicKey {
+public:
+  using seal::PublicKey::PublicKey;
+  AsealPublicKey(const seal::PublicKey &pk) : seal::PublicKey(pk) {};
+  ~AsealPublicKey(){};
+  ACiphertext& data() override {
+    AsealCiphertext* ctxt = new AsealCiphertext(seal::PublicKey::data());
+    return _from_ciphertext(*ctxt);
+  }
+};
+
+// DYNAMIC CASTING
+inline AsealPublicKey& _to_public_key(APublicKey& k){
+  return dynamic_cast<AsealPublicKey&>(k);
+};
+inline APublicKey& _from_public_key(AsealPublicKey& k){
+  return dynamic_cast<APublicKey&>(k);
+};
+
+/**
+ * @brief Abstraction for SecretKey
+*/
+class AsealSecretKey : public ASecretKey, public seal::SecretKey {
+public:
+  using seal::SecretKey::SecretKey;
+  AsealSecretKey(const seal::SecretKey &sk) : seal::SecretKey(sk) {};
+  ~AsealSecretKey(){};
+  APlaintext& data() override {
+    AsealPlaintext* ctxt = new AsealPlaintext(seal::SecretKey::data());
+    return _from_plaintext(*ctxt);
+  }
+};
+
+// DYNAMIC CASTING
+inline AsealSecretKey& _to_secret_key(ASecretKey& k){
+  return dynamic_cast<AsealSecretKey&>(k);
+};
+inline ASecretKey& _from_secret_key(AsealSecretKey& k){
+  return dynamic_cast<ASecretKey&>(k);
 };
 
 /**
@@ -201,11 +253,8 @@ public:
   void mod_switch_to_next(APlaintext &ptxt) override;
   void mod_switch_to_next(ACiphertext &ctxt) override;
   void rescale_to_next(ACiphertext &ctxt) override;
-  // string get_secret_key() override;
-  // string get_public_key() override;
-
-  void setPublicKey(seal::PublicKey &pubKey) { this->publicKey = make_shared<seal::PublicKey>(pubKey); }
-  void setSecretKey(seal::SecretKey &secKey) { this->secretKey = make_shared<seal::SecretKey>(secKey); }
+  APublicKey& get_public_key() override;
+  ASecretKey& get_secret_key() override;
 
   // ------------------ Cryptography ------------------
 

--- a/include/backend/aseal.h
+++ b/include/backend/aseal.h
@@ -139,10 +139,10 @@ public:
   using seal::PublicKey::PublicKey;
   AsealPublicKey(const seal::PublicKey &pk) : seal::PublicKey(pk) {};
   ~AsealPublicKey(){};
-  ACiphertext& data() override {
-    AsealCiphertext* ctxt = new AsealCiphertext(seal::PublicKey::data());
-    return _from_ciphertext(*ctxt);
-  }
+  // ACiphertext& data() override {
+  //   AsealCiphertext* ctxt = new AsealCiphertext(seal::PublicKey::data());
+  //   return _from_ciphertext(*ctxt);
+  // }
 };
 
 // DYNAMIC CASTING
@@ -161,10 +161,10 @@ public:
   using seal::SecretKey::SecretKey;
   AsealSecretKey(const seal::SecretKey &sk) : seal::SecretKey(sk) {};
   ~AsealSecretKey(){};
-  APlaintext& data() override {
-    AsealPlaintext* ctxt = new AsealPlaintext(seal::SecretKey::data());
-    return _from_plaintext(*ctxt);
-  }
+  // APlaintext& data() override {
+  //   AsealPlaintext* ctxt = new AsealPlaintext(seal::SecretKey::data());
+  //   return _from_plaintext(*ctxt);
+  // }
 };
 
 // DYNAMIC CASTING
@@ -176,10 +176,30 @@ inline ASecretKey& _from_secret_key(AsealSecretKey& k){
 };
 
 /**
+ * @brief Abstraction for RelinKey
+*/
+class AsealRelinKey : public ARelinKey, public seal::RelinKeys {
+public:
+  using seal::RelinKeys::RelinKeys;
+  AsealRelinKey(const seal::RelinKeys &rk) : seal::RelinKeys(rk) {};
+  ~AsealRelinKey(){};
+};
+
+// DYNAMIC CASTING
+inline AsealRelinKey& _to_relin_keys(ARelinKey& k){
+  return dynamic_cast<AsealRelinKey&>(k);
+};
+inline ARelinKey& _from_relin_keys(AsealRelinKey& k){
+  return dynamic_cast<ARelinKey&>(k);
+};
+
+
+/**
  * @brief Aseal class represents a concrete implementation of the Afhe class using the Microsoft SEAL library.
  */
 class Aseal : public Afhe {
 private:
+  shared_ptr<seal::EncryptionParameters> params; /**< Pointer to the SEAL parameters object. */
   shared_ptr<seal::SEALContext> context;     /**< Pointer to the SEAL context object. */
   shared_ptr<seal::BatchEncoder> bEncoder;   /**< Pointer to the BatchEncoder object. */
   shared_ptr<seal::CKKSEncoder> cEncoder;    /**< Pointer to the CKKSEncoder object. */
@@ -243,6 +263,8 @@ public:
     return this->context;
   }
 
+  void disable_mod_switch() override;
+
   // ------------------ Keys ------------------
 
   void KeyGen() override;
@@ -255,6 +277,7 @@ public:
   void rescale_to_next(ACiphertext &ctxt) override;
   APublicKey& get_public_key() override;
   ASecretKey& get_secret_key() override;
+  ARelinKey& get_relin_keys() override;
 
   // ------------------ Cryptography ------------------
 

--- a/include/backend/aseal.h
+++ b/include/backend/aseal.h
@@ -263,6 +263,10 @@ public:
     return this->context;
   }
 
+  /**
+   * @brief Replaces the existing SEALContext with a new one,
+   * with the same parameters, however disables mod switching.
+  */
   void disable_mod_switch() override;
 
   // ------------------ Keys ------------------

--- a/src/backend/aseal.cpp
+++ b/src/backend/aseal.cpp
@@ -122,6 +122,18 @@ void Aseal::KeyGen()
   this->encryptor = make_shared<Encryptor>(seal_context, *this->publicKey);
 }
 
+APublicKey& Aseal::get_public_key()
+{
+  AsealPublicKey* publicKey = new AsealPublicKey(*this->publicKey);
+  return _from_public_key(*publicKey);
+}
+
+ASecretKey& Aseal::get_secret_key()
+{
+  AsealSecretKey* secretKey = new AsealSecretKey(*this->secretKey);
+  return _from_secret_key(*secretKey);
+}
+
 void Aseal::RelinKeyGen()
 {
   // Gather current context, resolves object

--- a/src/backend/aseal.cpp
+++ b/src/backend/aseal.cpp
@@ -25,7 +25,7 @@ string Aseal::ContextGen(scheme scheme,
                          vector<int> bit_sizes)
 { try {
   // Initialize parameters with scheme
-  EncryptionParameters param(scheme_map_to_seal.at(scheme));
+  this->params = make_shared<EncryptionParameters>(scheme_map_to_seal.at(scheme));
 
   /*
    * BGV encodes plaintext with “least significant bits”
@@ -34,10 +34,10 @@ string Aseal::ContextGen(scheme scheme,
   if (scheme == scheme::bfv || scheme == scheme::bgv)
   {
     // Set polynomial modulus degree
-    param.set_poly_modulus_degree(poly_modulus_degree);
+    this->params->set_poly_modulus_degree(poly_modulus_degree);
 
     // Set coefficient modulus
-    param.set_coeff_modulus(CoeffModulus::BFVDefault(poly_modulus_degree));
+    this->params->set_coeff_modulus(CoeffModulus::BFVDefault(poly_modulus_degree));
 
     /**
      * When plain_modulus_bit_size is set, batching is enabled, plain_modulus is not used
@@ -45,17 +45,17 @@ string Aseal::ContextGen(scheme scheme,
     */
     if (plain_modulus_bit_size > 0)
     {
-      param.set_plain_modulus(PlainModulus::Batching(poly_modulus_degree, plain_modulus_bit_size));
+      this->params->set_plain_modulus(PlainModulus::Batching(poly_modulus_degree, plain_modulus_bit_size));
     }
     else
     {
-      param.set_plain_modulus(plain_modulus);
+      this->params->set_plain_modulus(plain_modulus);
     }
   }
   else if (scheme == scheme::ckks)
   {
     // Set polynomial modulus degree
-    param.set_poly_modulus_degree(poly_modulus_degree);
+    this->params->set_poly_modulus_degree(poly_modulus_degree);
 
     if (bit_sizes.size() == 0)
     {
@@ -68,14 +68,14 @@ string Aseal::ContextGen(scheme scheme,
     }
 
     // Set coefficient modulus
-    param.set_coeff_modulus(CoeffModulus::Create(poly_modulus_degree, bit_sizes));
+    this->params->set_coeff_modulus(CoeffModulus::Create(poly_modulus_degree, bit_sizes));
 
     // Set CKKS Encoder scale
     this->cEncoderScale = plain_modulus_bit_size; //pow(2.0, plain_modulus_bit_size);
   }
 
   // Validate parameters by putting them inside a SEALContext
-  this->context = make_shared<SEALContext>(param, true, sec_map[sec_level]);
+  this->context = make_shared<SEALContext>(*this->params, true, sec_map[sec_level]);
 
   // Initialize Encoder object
   if(this->context->parameters_set() && plain_modulus_bit_size > 0)
@@ -99,6 +99,12 @@ string Aseal::ContextGen(scheme scheme,
   catch (invalid_argument &e) {
     return string("invalid_argument: ") + e.what();
   }
+}
+
+void Aseal::disable_mod_switch()
+{
+  // Update existing context with same parameters
+  this->context = make_shared<SEALContext>(*this->params, false);
 }
 
 void Aseal::KeyGen()
@@ -132,6 +138,11 @@ ASecretKey& Aseal::get_secret_key()
 {
   AsealSecretKey* secretKey = new AsealSecretKey(*this->secretKey);
   return _from_secret_key(*secretKey);
+}
+
+ARelinKey& Aseal::get_relin_keys(){
+  AsealRelinKey* relinKeys = new AsealRelinKey(*this->relinKeys);
+  return _from_relin_keys(*relinKeys);
 }
 
 void Aseal::RelinKeyGen()

--- a/test/seal/basics/1_bfv.cpp
+++ b/test/seal/basics/1_bfv.cpp
@@ -1,6 +1,6 @@
 #include "basics.h"
 
-TEST(BFV, Basics)
+TEST(Basics, BFV)
 {
     /*
     In this example, we demonstrate performing simple computations (a polynomial

--- a/test/seal/basics/3_levels.cpp
+++ b/test/seal/basics/3_levels.cpp
@@ -1,6 +1,6 @@
 #include "basics.h"
 
-TEST(LEVELS, Basics)
+TEST(Basics, Levels)
 {
     /*
     In this examples we describe the concept of `levels' in BFV and CKKS and the
@@ -256,6 +256,7 @@ TEST(LEVELS, Basics)
     cout << "Decrypt still works after modulus switching." << endl;
     fhe->decrypt(encrypted, plain);
     cout << "    + Decryption of encrypted: " << plain.to_string();
+    EXPECT_STREQ(plain.to_string().c_str(), "1x^3 + 2x^2 + 3x^1 + 4");
     cout << " ...... Correct." << endl << endl;
 
     /*
@@ -318,10 +319,11 @@ TEST(LEVELS, Basics)
     can be used to decrypt a ciphertext at any level in the modulus switching
     chain.
     */
-    fhe->decrypt(encrypted, plain);
-    cout << "    + Decryption of the 8th power (hexadecimal) ...... Correct." << endl;
-    cout << "    " << plain.to_string() << endl << endl;
-
+    fhe->decrypt(eighth_power, plain);
+    cout << "    + Decryption of the 8th power (hexadecimal)" << endl;
+    cout << "    " << plain.to_string();
+    EXPECT_STREQ(plain.to_string().c_str(), "1x^24 + 10x^23 + 88x^22 + 330x^21 + EFCx^20 + 3A30x^19 + C0B8x^18 + 22BB0x^17 + 58666x^16 + C88D0x^15 + 9C377x^14 + F4C0Ex^13 + E8B38x^12 + 5EE89x^11 + F8BFFx^10 + 30304x^9 + 5B9D4x^8 + 12653x^7 + 4DFB5x^6 + 879F8x^5 + 825FBx^4 + F1FFEx^3 + 3FFFFx^2 + 60000x^1 + 10000");
+    cout << " ...... Correct." << endl << endl;
     /*
     In BFV modulus switching is not necessary and in some cases the user might
     not want to create the modulus switching chain, except for the highest two

--- a/test/seal/basics/3_levels.cpp
+++ b/test/seal/basics/3_levels.cpp
@@ -1,0 +1,340 @@
+#include "basics.h"
+
+TEST(LEVELS, Basics)
+{
+    /*
+    In this examples we describe the concept of `levels' in BFV and CKKS and the
+    related objects that represent them in Microsoft SEAL.
+
+    In Microsoft SEAL a set of encryption parameters (excluding the random number
+    generator) is identified uniquely by a 256-bit hash of the parameters. This
+    hash is called the `parms_id' and can be easily accessed and printed at any
+    time. The hash will change as soon as any of the parameters is changed.
+
+    When a SEALContext is created from a given EncryptionParameters instance,
+    Microsoft SEAL automatically creates a so-called `modulus switching chain',
+    which is a chain of other encryption parameters derived from the original set.
+    The parameters in the modulus switching chain are the same as the original
+    parameters with the exception that size of the coefficient modulus is
+    decreasing going down the chain. More precisely, each parameter set in the
+    chain attempts to remove the last coefficient modulus prime from the
+    previous set; this continues until the parameter set is no longer valid
+    (e.g., plain_modulus is larger than the remaining coeff_modulus). It is easy
+    to walk through the chain and access all the parameter sets. Additionally,
+    each parameter set in the chain has a `chain index' that indicates its
+    position in the chain so that the last set has index 0. We say that a set
+    of encryption parameters, or an object carrying those encryption parameters,
+    is at a higher level in the chain than another set of parameters if its the
+    chain index is bigger, i.e., it is earlier in the chain.
+
+    Each set of parameters in the chain involves unique pre-computations performed
+    when the SEALContext is created, and stored in a SEALContext::ContextData
+    object. The chain is basically a linked list of SEALContext::ContextData
+    objects, and can easily be accessed through the SEALContext at any time. Each
+    node can be identified by the parms_id of its specific encryption parameters
+    (poly_modulus_degree remains the same but coeff_modulus varies).
+
+    In this example we use a custom coeff_modulus, consisting of 5 primes of
+    sizes 50, 30, 30, 50, and 50 bits. Note that this is still OK according to
+    the explanation in `1_bfv_basics.cpp'. Indeed,
+
+        CoeffModulus::MaxBitCount(poly_modulus_degree)
+
+    returns 218 (greater than 50+30+30+50+50=210).
+
+    Due to the modulus switching chain, the order of the 5 primes is significant.
+    The last prime has a special meaning and we call it the `special prime'. Thus,
+    the first parameter set in the modulus switching chain is the only one that
+    involves the special prime. All key objects, such as SecretKey, are created
+    at this highest level. All data objects, such as Ciphertext, can be only at
+    lower levels. The special prime should be as large as the largest of the
+    other primes in the coeff_modulus, although this is not a strict requirement.
+
+              special prime +---------+
+                                      |
+                                      v
+    coeff_modulus: { 50, 30, 30, 50, 50 }  +---+  Level 4 (all keys; `key level')
+                                               |
+                                               |
+        coeff_modulus: { 50, 30, 30, 50 }  +---+  Level 3 (highest `data level')
+                                               |
+                                               |
+            coeff_modulus: { 50, 30, 30 }  +---+  Level 2
+                                               |
+                                               |
+                coeff_modulus: { 50, 30 }  +---+  Level 1
+                                               |
+                                               |
+                    coeff_modulus: { 50 }  +---+  Level 0 (lowest level)
+    */
+    vector<uint64_t> coeff_modulus = { 50, 30, 30, 50, 50 };
+    size_t poly_modulus_degree = 8192;
+    size_t poly_modulus_bit_size = 20; // Enable Batching
+    int security_level = 128;
+    /*
+    In this example the plain_modulus does not play much of a role; we choose
+    some reasonable value.
+    */
+    Aseal* fhe = new Aseal();
+    string ctx = fhe->ContextGen(scheme::bfv, poly_modulus_degree, poly_modulus_bit_size, 0, security_level);
+    EXPECT_STREQ(ctx.c_str(), "success: valid");
+    auto context = fhe->get_context();
+    print_parameters(context);
+
+    /*
+    There are convenience method for accessing the SEALContext::ContextData for
+    some of the most important levels:
+
+        SEALContext::key_context_data(): access to key level ContextData
+        SEALContext::first_context_data(): access to highest data level ContextData
+        SEALContext::last_context_data(): access to lowest level ContextData
+
+    We iterate over the chain and print the parms_id for each set of parameters.
+    */
+    print_line(__LINE__);
+    cout << "Print the modulus switching chain." << endl;
+
+    /*
+    First print the key level parameter information.
+    */
+    auto context_data = context->key_context_data();
+
+    cout << "----> Level (chain index): " << context_data->chain_index();
+    cout << " ...... key_context_data()" << endl;
+    cout << "      parms_id: " << hex;
+    for (const auto &param : context_data->parms_id())
+    {
+        cout << param << " ";
+    }
+    cout << endl;
+    cout << "      coeff_modulus primes: ";
+    cout << hex;
+    for (const auto &prime : context_data->parms().coeff_modulus())
+    {
+        cout << prime.value() << " ";
+    }
+    cout << dec << endl;
+    cout << "\\" << endl;
+    cout << " \\-->";
+
+    /*
+    Next iterate over the remaining (data) levels.
+    */
+    context_data = context->first_context_data();
+    while (context_data)
+    {
+        cout << " Level (chain index): " << context_data->chain_index();
+        if (context_data->parms_id() == context->first_parms_id())
+        {
+            cout << " ...... first_context_data()" << endl;
+        }
+        else if (context_data->parms_id() == context->last_parms_id())
+        {
+            cout << " ...... last_context_data()" << endl;
+        }
+        else
+        {
+            cout << endl;
+        }
+        cout << "      parms_id: " << hex;
+        for (const auto &param : context_data->parms_id())
+        {
+            cout << param << " ";
+        }
+        cout << endl;
+        cout << "      coeff_modulus primes: ";
+        cout << hex;
+        for (const auto &prime : context_data->parms().coeff_modulus())
+        {
+            cout << prime.value() << " ";
+        }
+        cout << dec << endl;
+        cout << "\\" << endl;
+        cout << " \\-->";
+
+        /*
+        Step forward in the chain.
+        */
+        context_data = context_data->next_context_data();
+    }
+    cout << " End of chain reached" << endl << endl;
+
+    /*
+    We create some keys and check that indeed they appear at the highest level.
+    */
+    fhe->KeyGen();
+    AsealPublicKey& public_key = _to_public_key(fhe->get_public_key());
+    AsealSecretKey& secret_key = _to_secret_key(fhe->get_secret_key());
+    // auto secret_key = fhe->get_secret_key();
+    // fhe->RelinKeyGen();
+    // auto relin_keys = fhe->get_relin_keys();
+
+    print_line(__LINE__);
+    cout << "Print the parameter IDs of generated elements." << endl;
+    cout << "    + public_key:  " << hex;
+    for (const auto &param : public_key.parms_id())
+    {
+        cout << param << " ";
+    }
+    cout << endl;
+    cout << "    + secret_key:  " << hex;
+    for (const auto &param : secret_key.parms_id())
+    {
+        cout << param << " ";
+    }
+    cout << endl;
+    // cout << "    + relin_keys:  " << relin_keys.parms_id() << endl;
+
+    // Encryptor encryptor(context, public_key);
+    // Evaluator evaluator(context);
+    // Decryptor decryptor(context, secret_key);
+
+    // /*
+    // In the BFV scheme plaintexts do not carry a parms_id, but ciphertexts do. Note
+    // how the freshly encrypted ciphertext is at the highest data level.
+    // */
+    // Plaintext plain("1x^3 + 2x^2 + 3x^1 + 4");
+    // Ciphertext encrypted;
+    // encryptor.encrypt(plain, encrypted);
+    // cout << "    + plain:       " << plain.parms_id() << " (not set in BFV)" << endl;
+    // cout << "    + encrypted:   " << encrypted.parms_id() << endl << endl;
+
+    // /*
+    // `Modulus switching' is a technique of changing the ciphertext parameters down
+    // in the chain. The function Evaluator::mod_switch_to_next always switches to
+    // the next level down the chain, whereas Evaluator::mod_switch_to switches to
+    // a parameter set down the chain corresponding to a given parms_id. However, it
+    // is impossible to switch up in the chain.
+    // */
+    // print_line(__LINE__);
+    // cout << "Perform modulus switching on encrypted and print." << endl;
+    // context_data = context.first_context_data();
+    // cout << "---->";
+    // while (context_data->next_context_data())
+    // {
+    //     cout << " Level (chain index): " << context_data->chain_index() << endl;
+    //     cout << "      parms_id of encrypted: " << encrypted.parms_id() << endl;
+    //     cout << "      Noise budget at this level: " << decryptor.invariant_noise_budget(encrypted) << " bits" << endl;
+    //     cout << "\\" << endl;
+    //     cout << " \\-->";
+    //     evaluator.mod_switch_to_next_inplace(encrypted);
+    //     context_data = context_data->next_context_data();
+    // }
+    // cout << " Level (chain index): " << context_data->chain_index() << endl;
+    // cout << "      parms_id of encrypted: " << encrypted.parms_id() << endl;
+    // cout << "      Noise budget at this level: " << decryptor.invariant_noise_budget(encrypted) << " bits" << endl;
+    // cout << "\\" << endl;
+    // cout << " \\-->";
+    // cout << " End of chain reached" << endl << endl;
+
+    // /*
+    // At this point it is hard to see any benefit in doing this: we lost a huge
+    // amount of noise budget (i.e., computational power) at each switch and seemed
+    // to get nothing in return. Decryption still works.
+    // */
+    // print_line(__LINE__);
+    // cout << "Decrypt still works after modulus switching." << endl;
+    // decryptor.decrypt(encrypted, plain);
+    // cout << "    + Decryption of encrypted: " << plain.to_string();
+    // cout << " ...... Correct." << endl << endl;
+
+    // /*
+    // However, there is a hidden benefit: the size of the ciphertext depends
+    // linearly on the number of primes in the coefficient modulus. Thus, if there
+    // is no need or intention to perform any further computations on a given
+    // ciphertext, we might as well switch it down to the smallest (last) set of
+    // parameters in the chain before sending it back to the secret key holder for
+    // decryption.
+
+    // Also the lost noise budget is actually not an issue at all, if we do things
+    // right, as we will see below.
+
+    // First we recreate the original ciphertext and perform some computations.
+    // */
+    // cout << "Computation is more efficient with modulus switching." << endl;
+    // print_line(__LINE__);
+    // cout << "Compute the 8th power." << endl;
+    // encryptor.encrypt(plain, encrypted);
+    // cout << "    + Noise budget fresh:                   " << decryptor.invariant_noise_budget(encrypted) << " bits"
+    //      << endl;
+    // evaluator.square_inplace(encrypted);
+    // evaluator.relinearize_inplace(encrypted, relin_keys);
+    // cout << "    + Noise budget of the 2nd power:         " << decryptor.invariant_noise_budget(encrypted) << " bits"
+    //      << endl;
+    // evaluator.square_inplace(encrypted);
+    // evaluator.relinearize_inplace(encrypted, relin_keys);
+    // cout << "    + Noise budget of the 4th power:         " << decryptor.invariant_noise_budget(encrypted) << " bits"
+    //      << endl;
+
+    // /*
+    // Surprisingly, in this case modulus switching has no effect at all on the
+    // noise budget.
+    // */
+    // evaluator.mod_switch_to_next_inplace(encrypted);
+    // cout << "    + Noise budget after modulus switching:  " << decryptor.invariant_noise_budget(encrypted) << " bits"
+    //      << endl;
+    // /*
+    // This means that there is no harm at all in dropping some of the coefficient
+    // modulus after doing enough computations. In some cases one might want to
+    // switch to a lower level slightly earlier, actually sacrificing some of the
+    // noise budget in the process, to gain computational performance from having
+    // smaller parameters. We see from the print-out that the next modulus switch
+    // should be done ideally when the noise budget is down to around 25 bits.
+    // */
+    // evaluator.square_inplace(encrypted);
+    // evaluator.relinearize_inplace(encrypted, relin_keys);
+    // cout << "    + Noise budget of the 8th power:         " << decryptor.invariant_noise_budget(encrypted) << " bits"
+    //      << endl;
+    // evaluator.mod_switch_to_next_inplace(encrypted);
+    // cout << "    + Noise budget after modulus switching:  " << decryptor.invariant_noise_budget(encrypted) << " bits"
+    //      << endl;
+
+    // /*
+    // At this point the ciphertext still decrypts correctly, has very small size,
+    // and the computation was as efficient as possible. Note that the decryptor
+    // can be used to decrypt a ciphertext at any level in the modulus switching
+    // chain.
+    // */
+    // decryptor.decrypt(encrypted, plain);
+    // cout << "    + Decryption of the 8th power (hexadecimal) ...... Correct." << endl;
+    // cout << "    " << plain.to_string() << endl << endl;
+
+    // /*
+    // In BFV modulus switching is not necessary and in some cases the user might
+    // not want to create the modulus switching chain, except for the highest two
+    // levels. This can be done by passing a bool `false' to SEALContext constructor.
+    // */
+    // context = SEALContext(parms, false);
+
+    // /*
+    // We can check that indeed the modulus switching chain has been created only
+    // for the highest two levels (key level and highest data level). The following
+    // loop should execute only once.
+    // */
+    // cout << "Optionally disable modulus switching chain expansion." << endl;
+    // print_line(__LINE__);
+    // cout << "Print the modulus switching chain." << endl;
+    // cout << "---->";
+    // for (context_data = context.key_context_data(); context_data; context_data = context_data->next_context_data())
+    // {
+    //     cout << " Level (chain index): " << context_data->chain_index() << endl;
+    //     cout << "      parms_id: " << context_data->parms_id() << endl;
+    //     cout << "      coeff_modulus primes: ";
+    //     cout << hex;
+    //     for (const auto &prime : context_data->parms().coeff_modulus())
+    //     {
+    //         cout << prime.value() << " ";
+    //     }
+    //     cout << dec << endl;
+    //     cout << "\\" << endl;
+    //     cout << " \\-->";
+    // }
+    // cout << " End of chain reached" << endl << endl;
+
+    /*
+    It is very important to understand how this example works since in the BGV
+    scheme modulus switching has a much more fundamental purpose and the next
+    examples will be difficult to understand unless these basic properties are
+    totally clear.
+    */
+}

--- a/test/seal/basics/3_levels.cpp
+++ b/test/seal/basics/3_levels.cpp
@@ -338,8 +338,6 @@ TEST(LEVELS, Basics)
     loop should execute only once.
     */
     cout << "Optionally disable modulus switching chain expansion." << endl;
-    print_line(__LINE__);
-    cout << "Print the modulus switching chain." << endl;
     cout << "---->";
     for (context_data = context->key_context_data(); context_data; context_data = context_data->next_context_data())
     {

--- a/test/seal/basics/4_bgv.cpp
+++ b/test/seal/basics/4_bgv.cpp
@@ -1,6 +1,6 @@
 #include "basics.h"
 
-TEST(BGV, Basics)
+TEST(Basics, BGV)
 {
      /*
      As an example, we evaluate the degree 8 polynomial

--- a/test/seal/basics/5_ckks.cpp
+++ b/test/seal/basics/5_ckks.cpp
@@ -1,6 +1,6 @@
 #include "basics.h"
 
-TEST(CKKS, Basics)
+TEST(Basics, CKKS)
 {
     /*
     In this example we demonstrate evaluating a polynomial function


### PR DESCRIPTION
https://github.com/microsoft/SEAL/blob/main/native/examples/3_levels.cpp
```
[ RUN      ] Basics.Levels
/
| Encryption parameters:
|   scheme: BFV
|   poly_modulus_degree: 8192
|   coeff_modulus size: 5 (43 + 43 + 44 + 44 + 44) bits
|   plain_modulus: 1032193
\
Line  94 --> Print the modulus switching chain.
----> Level (chain index): 4 ...... key_context_data()
      parms_id: f9ece899e98dc76c 461b0a7748fa8c61 88e468603ecbbd8e 75feb3e1288c08b8 
      coeff_modulus primes: 7fffffd8001 7fffffc8001 fffffffc001 ffffff6c001 fffffebc001 
\
 \--> Level (chain index): 3 ...... first_context_data()
      parms_id: 23ae23fc1ed2a1b6 90ae48e187641b71 d7611ddf0056f6a7 d4ce43eef038575f 
      coeff_modulus primes: 7fffffd8001 7fffffc8001 fffffffc001 ffffff6c001 
\
 \--> Level (chain index): 2
      parms_id: 783297d2e7d9b749 80e40178a3bd9991 e84fed758f28b19a 2192abbc157b996a 
      coeff_modulus primes: 7fffffd8001 7fffffc8001 fffffffc001 
\
 \--> Level (chain index): 1
      parms_id: 748291d211394e8e 28b3a2963de475b0 382acfd0e00205b5 bab66082d91dc08a 
      coeff_modulus primes: 7fffffd8001 7fffffc8001 
\
 \--> Level (chain index): 0 ...... last_context_data()
      parms_id: 8b59c1c982f0a72d bce1ddc82ae8dc9f 68952fcaa638d78a b80046009fe3e881 
      coeff_modulus primes: 7fffffd8001 
\
 \--> End of chain reached

Line 171 --> Print the parameter IDs of generated elements.
    + public_key:  f9ece899e98dc76c 461b0a7748fa8c61 88e468603ecbbd8e 75feb3e1288c08b8 
    + secret_key:  f9ece899e98dc76c 461b0a7748fa8c61 88e468603ecbbd8e 75feb3e1288c08b8 
    + relin_keys:  f9ece899e98dc76c 461b0a7748fa8c61 88e468603ecbbd8e 75feb3e1288c08b8 

    + plain:       0 0 0 0  (not set in BFV)
    + encrypted:   23ae23fc1ed2a1b6 90ae48e187641b71 d7611ddf0056f6a7 d4ce43eef038575f 

Line 219 --> Perform modulus switching on encrypted and print.
----> Level (chain index): 3
      parms_id of encrypted: 23ae23fc1ed2a1b6 90ae48e187641b71 d7611ddf0056f6a7 d4ce43eef038575f 
      Noise budget at this level: 146 bits
\
 \--> Level (chain index): 2
      parms_id of encrypted: 783297d2e7d9b749 80e40178a3bd9991 e84fed758f28b19a 2192abbc157b996a 
      Noise budget at this level: 102 bits
\
 \--> Level (chain index): 1
      parms_id of encrypted: 748291d211394e8e 28b3a2963de475b0 382acfd0e00205b5 bab66082d91dc08a 
      Noise budget at this level: 58 bits
\
 \--> Level (chain index): 0
      parms_id of encrypted: 8b59c1c982f0a72d bce1ddc82ae8dc9f 68952fcaa638d78a b80046009fe3e881 
      Noise budget at this level: 15 bits
\
 \--> End of chain reached

Line 255 --> Decrypt still works after modulus switching.
    + Decryption of encrypted: 1x^3 + 2x^2 + 3x^1 + 4 ...... Correct.

Computation is more efficient with modulus switching.
Line 276 --> Compute the 8th power.
    + Noise budget fresh:                    146 bits
    + Noise budget of the 2nd power:         114 bits
    + Noise budget of the 4th power:         81 bits
    + Noise budget after modulus switching:  81 bits
    + Noise budget of the 8th power:         48 bits
    + Noise budget after modulus switching:  48 bits
    + Decryption of the 8th power (hexadecimal)
    1x^24 + 10x^23 + 88x^22 + 330x^21 + EFCx^20 + 3A30x^19 + C0B8x^18 + 22BB0x^17 + 58666x^16 + C88D0x^15 + 9C377x^14 + F4C0Ex^13 + E8B38x^12 + 5EE89x^11 + F8BFFx^10 + 30304x^9 + 5B9D4x^8 + 12653x^7 + 4DFB5x^6 + 879F8x^5 + 825FBx^4 + F1FFEx^3 + 3FFFFx^2 + 60000x^1 + 10000 ...... Correct.

Line 332 --> Disable modulus switching chain.
Optionally disable modulus switching chain expansion.
----> Level (chain index): 1
      parms_id: f9ece899e98dc76c 461b0a7748fa8c61 88e468603ecbbd8e 75feb3e1288c08b8 
      coeff_modulus primes: 7fffffd8001 7fffffc8001 fffffffc001 ffffff6c001 fffffebc001 
\
 \--> Level (chain index): 0
      parms_id: 23ae23fc1ed2a1b6 90ae48e187641b71 d7611ddf0056f6a7 d4ce43eef038575f 
      coeff_modulus primes: 7fffffd8001 7fffffc8001 fffffffc001 ffffff6c001 
\
 \--> End of chain reached

[       OK ] Basics.Levels (1891 ms)